### PR TITLE
Fixed compile errors in examples for AV2221

### DIFF
--- a/Guidelines/2200_FrameworkGuidelines.md
+++ b/Guidelines/2200_FrameworkGuidelines.md
@@ -40,14 +40,14 @@ Since LINQ queries should be written out over multiple lines for readability, th
 
 Lambda expressions provide a much more elegant alternative for anonymous delegates. So instead of:
 
-	Customer c = Array.Find(customers, delegate(Customer c)
+	Customer customer = Array.Find(customers, delegate(Customer c)
 	{
 		return c.Name == "Tom";
 	});
 
 use a Lambda expression:
 
-	Customer c = Array.Find(customers, c => c.Name == "Tom");
+	Customer customer = Array.Find(customers, c => c.Name == "Tom");
 
 Or even better:
 


### PR DESCRIPTION
CS0136: A local or parameter named 'c' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter.