### PR TITLE
Switched names to match with AV1738.

### DIFF
--- a/Src/Guidelines/1700_NamingGuidelines.md
+++ b/Src/Guidelines/1700_NamingGuidelines.md
@@ -42,7 +42,7 @@ In most cases they are a lazy excuse for not defining a clear and intention-reve
 For example, don't use `g_` or `s_` to distinguish static from non-static fields. A method in which it is difficult to distinguish local variables from member fields is generally too big. Examples of incorrect identifier names are: `_currentUser`, `mUserName`, `m_loginTime`.
 
 ### <a name="av1706"></a> Don't use abbreviations  (AV1706) ![](images/2.png)
-For example, use `OnButtonClick` rather than `OnBtnClick`. Avoid single character variable names, such as `i` or `q`. Use `index` or `query` instead.
+For example, use `ButtonOnClick` rather than `BtnOnClick`. Avoid single character variable names, such as `i` or `q`. Use `index` or `query` instead.
 
 **Exceptions:** Use well-known abbreviations that are widely accepted or well-known in your work domain. For instance, use `UI` instead of `UserInterface`.
 


### PR DESCRIPTION
AV1738 says: "It is good practice to prefix the method that handles an event with On. For example, a method that handles the Closing event can be named OnClosing."

Since the example in AV1706 refers to the Click event, its handler name should be something with "OnClick" in it.
