### PR TITLE
Fixed formatting in GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ Coding Guidelines for C# 3.0, 4.0 and 5.0
 [![Join the chat at https://gitter.im/dennisdoomen/csharpguidelines](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/dennisdoomen/csharpguidelines?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build status](https://ci.appveyor.com/api/projects/status/abdiejvl9jp9h60l?svg=true)](https://ci.appveyor.com/project/dennisdoomen/csharpguidelines)
 
-##What is this##
+## What is this
 This document attempts to provide guidelines (or coding standards if you like) for coding in C# 3.0, 4.0 or 5.0 that are both useful and pragmatic. Of course, if you create such a document you should practice what you preach. So rest assured, these guidelines are representative to what we at [Aviva Solutions](http://www.avivasolutions.nl) do in our day-to-day work. Notice that not all guidelines have a clear rationale. Some of them are simply choices we made at Aviva Solutions. In the end, it doesn't matter what choice you made, as long as you make one and apply it consistently.
 
-##Why would you use this document?##
+## Why would you use this document?
 Although some might see coding guidelines as undesired overhead or something that limits creativity, this approach has already proven its value for many years. This is because not every developer:
 
 - is aware that code is generally read 10 times more than it is changed;
@@ -16,15 +16,15 @@ Although some might see coding guidelines as undesired overhead or something tha
 - is aware of the impact of using (or neglecting to use) particular solutions on aspects like security, performance, multi-language support, etc;
 - realizes that not every developer is as capable, skilled or experienced to understand elegant, but potentially very abstract solutions;
 
-##Where do I get them?##
+## Where do I get them?
 Go to the [Releases](https://github.com/dennisdoomen/CSharpGuidelines/releases) page to find the latest HTML, PDF and other related files.
 
-##Can I create my own version?##
+## Can I create my own version?
 Absolutely. The corresponding [license](https://github.com/dennisdoomen/CSharpGuidelines/blob/master/LICENSE.md) allows you to fork, adapt and distribute that modified version within your organization as long as you refer back to the original version here. It's not required, but you would make me a very happy man if you credit me as the original author. And if you have any great ideas, recommendations or corrections, either submit an issue, or even better, fork the repository and provide me with a pull request. Just run the following command-line to compile the Markdown versions of the guidelines and cheatsheet to self-contained HTML files.
 
   `build.bat`
-##Are there any other languages available?##
+## Are there any other languages available?
 Yes, [Sergey Russkikh](https://twitter.com/Russkikh_Sergey) maintains a [Russian translation](https://github.com/SergeyRusskih/CSharpGuidelines.Russian) through his fork.
 
-##Is there tooling support?
+## Is there tooling support?
 A code analyzer that verifies over 40 of these guidelines is available at https://github.com/bkoelman/CSharpGuidelinesAnalyzer. This open source tool can be run during CI builds or while typing code in Visual Studio 2015/2017. An updated Resharper settings file is included.

--- a/Src/Guidelines/0001_Introduction.md
+++ b/Src/Guidelines/0001_Introduction.md
@@ -2,14 +2,14 @@
 NOTE: Requires Markdown Extra. See http://michelf.ca/projects/php-markdown/extra/
  --> 
 
-#1. Introduction#
-##1.1. What is this?##
+# 1. Introduction
+## 1.1. What is this?
 
 This document attempts to provide guidelines (or coding standards if you like) for coding in C# 3.0, 4.0 or 5.0 that are both useful and pragmatic. Of course, if you create such a document you should practice what you preach. So rest assured, these guidelines are representative to what we at [Aviva Solutions](http://www.avivasolutions.nl) do in our day-to-day work. Notice that not all guidelines have a clear rationale. Some of them are simply choices we made at Aviva Solutions. In the end, it doesn't matter what choice you made, as long as you make one and apply it consistently.
 
 Visual Studio's [Static Code Analysis](http://msdn.microsoft.com/en-us/library/dd264939.aspx) (which is also known as FxCop) and [StyleCop](http://stylecop.codeplex.com/) can already automatically enforce a lot of coding and design rules by analyzing the compiled assemblies. You can configure it to do that at compile time or as part of a continuous or daily build. The companion site [www.csharpcodingguidelines.com](http://www.csharpcodingguidelines.com) provides a list of code analysis rules depending on the type of code base you're dealing with. This document just provides an additional set of rules and recommendations that should help you achieve a more maintainable code base.
 
-##1.2. Why would you use this document?##
+## 1.2. Why would you use this document?
 
 Although some might see coding guidelines as undesired overhead or something that limits creativity, this approach has already proven its value for many years. This is because not every developer:
 
@@ -19,7 +19,7 @@ Although some might see coding guidelines as undesired overhead or something tha
 - is aware of the impact of using (or neglecting to use) particular solutions on aspects like security, performance, multi-language support, etc;
 - realizes that not every developer is as capable, skilled or experienced to understand elegant, but potentially very abstract solutions;
 
-##1.3. Basic principles##
+## 1.3. Basic principles
 
 There are many unexpected things I run into during my work as a consultant, each deserving at least one guideline. Unfortunately, I still need to keep this document within a reasonable size. But unlike what some junior developers believe, that doesn't mean that something is okay just because it is not mentioned in this document.
 
@@ -33,7 +33,7 @@ In general, if I have a discussion with a colleague about a smell that this docu
 
 Regardless of the elegance of someone's solution, if it's too complex for the ordinary developer, exposes unusual behavior, or tries to solve many possible future issues, it is very likely the wrong solution and needs redesign. The worst response a developer can give you to these principles is: "But it works?". 
 
-##1.4. How do you get started?##
+## 1.4. How do you get started?
 
 - Ask all developers to carefully read this document at least once. This will give them a sense of the kind of guidelines the document contains. 
 - Make sure there are always a few hard copies of the [Quick Reference](http://www.csharpcodingguidelines.com/) close at hand. 
@@ -47,7 +47,7 @@ Regardless of the elegance of someone's solution, if it's too complex for the or
 - ReSharper also has a File Structure window that displays an overview of the members of your class or interface, and allows you to easily rearrange them using a simple drag-and-drop action. 
 - Using [GhostDoc](http://submain.com/products/ghostdoc.aspx) you can generate XML comments for any member using a keyboard shortcut. The beauty of it is that it closely follows the MSDN-style of documentation. However, you have to be careful not to misuse this tool, and use it as a starter only. 
 
-##1.5. Why did we create it?##
+## 1.5. Why did we create it?
 
 The idea started in 2002 when Vic Hartog (Philips Medical Systems) and I were assigned the task of writing up a [coding standard](http://www.tiobe.com/content/paperinfo/gemrcsharpcs.pdf) for C# 1.0. Since then, I've regularly added, removed and changed rules based on experiences, feedback from the community and new tooling support offered by a continuous stream of new Visual Studio releases.
 
@@ -55,7 +55,7 @@ Additionally, after reading [Robert C. Martin](http://www.objectmentor.com/omTea
 
 I've also decided to include some design guidelines in addition to simple coding guidelines. They are too important to ignore and have a big influence in reaching high quality code.
 
-##1.6. Is this a coding standard?##
+## 1.6. Is this a coding standard?
 
 The document does not state that projects must comply with these guidelines, neither does it say which guidelines are more important than others. However, we encourage projects to decide themselves which guidelines are important, what deviations a project will use, who is the consultant in case doubts arise, and what kind of layout must be used for source code. Obviously, you should make these decisions before starting the real coding work.
 
@@ -67,7 +67,7 @@ To help you in this decision, I've assigned a level of importance to each guidel
 
 ![](images/3.png) May not be applicable in all situations
 
-##1.7. Feedback and disclaimer##
+## 1.7. Feedback and disclaimer
 
 This document has been compiled using many contributions from community members, blog posts, on-line discussions and many years of developing in C#. If you have questions, comments or suggestions, just let me know by sending me an email at [dennis.doomen@avivasolutions.nl](mailto:dennis.doomen@avivasolutions.nl), [creating an issue](https://github.com/dennisdoomen/csharpguidelines/issues) or Pull Request on GitHub, or ping me at [http://twitter.com/ddoomen](http://twitter.com/ddoomen). I will try to revise and republish this document with new insights, experiences and remarks on a regular basis.
 

--- a/Src/Guidelines/1000_ClassDesignGuidelines.md
+++ b/Src/Guidelines/1000_ClassDesignGuidelines.md
@@ -2,7 +2,7 @@
 NOTE: Requires Markdown Extra. See http://michelf.ca/projects/php-markdown/extra/
  --> 
 
-#2. Class Design Guidelines
+# 2. Class Design Guidelines
 
 ### <a name="av1000"></a> A class or interface should have a single purpose (AV1000) ![](images/1.png)
 

--- a/Src/Guidelines/1100_MemberDesignGuidelines.md
+++ b/Src/Guidelines/1100_MemberDesignGuidelines.md
@@ -2,7 +2,7 @@
 NOTE: Requires Markdown Extra. See http://michelf.ca/projects/php-markdown/extra/
  --> 
 
-#3. Member Design Guidelines
+# 3. Member Design Guidelines
 
 ### <a name="av1100"></a> Allow properties to be set in any order (AV1100) ![](images/1.png)
 

--- a/Src/Guidelines/1200_MiscellaneousDesignGuidelines.md
+++ b/Src/Guidelines/1200_MiscellaneousDesignGuidelines.md
@@ -2,7 +2,7 @@
 NOTE: Requires Markdown Extra. See http://michelf.ca/projects/php-markdown/extra/
  --> 
 
-#4. Miscellaneous Design Guidelines
+# 4. Miscellaneous Design Guidelines
 
 ### <a name="av1200"></a> Throw exceptions rather than returning some kind of status value (AV1200) ![](images/2.png)
 

--- a/Src/Guidelines/1500_MaintainabilityGuidelines.md
+++ b/Src/Guidelines/1500_MaintainabilityGuidelines.md
@@ -2,7 +2,7 @@
 NOTE: Requires Markdown Extra. See http://michelf.ca/projects/php-markdown/extra/
  --> 
 
-#5. Maintainability Guidelines
+# 5. Maintainability Guidelines
 
 ### <a name="av1500"></a> Methods should not exceed 7 statements (AV1500) ![](images/1.png)
 A method that requires more than 7 statements is simply doing too much or has too many responsibilities. It also requires the human mind to analyze the exact statements to understand what the code is doing. Break it down into multiple small and focused methods with self-explaining names, but make sure the high-level algorithm is still clear.

--- a/Src/Guidelines/1700_NamingGuidelines.md
+++ b/Src/Guidelines/1700_NamingGuidelines.md
@@ -2,7 +2,7 @@
 NOTE: Requires Markdown Extra. See http://michelf.ca/projects/php-markdown/extra/
  --> 
 
-#6. Naming Guidelines
+# 6. Naming Guidelines
 
 ### <a name="av1701"></a> Use US-English (AV1701) ![](images/1.png)
 

--- a/Src/Guidelines/1800_PerformanceGuidelines.md
+++ b/Src/Guidelines/1800_PerformanceGuidelines.md
@@ -2,7 +2,7 @@
 NOTE: Requires Markdown Extra. See http://michelf.ca/projects/php-markdown/extra/
  --> 
 
-#7. Performance Guidelines
+# 7. Performance Guidelines
 
 ### <a name="av1800"></a> Consider using `Any()` to determine whether an `IEnumerable<T>` is empty (AV1800) ![](images/3.png)
 When a method or other member returns an `IEnumerable<T>` or other collection class that does not expose a `Count` property, use the `Any()` extension method rather than `Count()` to determine whether the collection contains items. If you do use `Count()`, you risk that iterating over the entire collection might have a significant impact (such as when it really is an `IQueryable<T>` to a persistent store).

--- a/Src/Guidelines/2200_FrameworkGuidelines.md
+++ b/Src/Guidelines/2200_FrameworkGuidelines.md
@@ -2,7 +2,7 @@
 NOTE: Requires Markdown Extra. See http://michelf.ca/projects/php-markdown/extra/
  --> 
 
-#8. Framework Guidelines
+# 8. Framework Guidelines
 
 ### <a name="av2201"></a> Use C# type aliases instead of the types from the `System` namespace  (AV2201) ![](images/1.png)
 For instance, use `object` instead of `Object`, `string` instead of `String`, and `int` instead of `Int32`. These aliases have been introduced to make the primitive types first class citizens of the C# language, so use them accordingly.

--- a/Src/Guidelines/2300_DocumentationGuidelines.md
+++ b/Src/Guidelines/2300_DocumentationGuidelines.md
@@ -2,7 +2,7 @@
 NOTE: Requires Markdown Extra. See http://michelf.ca/projects/php-markdown/extra/
  --> 
 
-#9. Documentation Guidelines
+# 9. Documentation Guidelines
 
 ### <a name="av2301"></a> Write comments and documentation in US English  (AV2301) ![](images/1.png)
 

--- a/Src/Guidelines/2400_LayoutGuidelines.md
+++ b/Src/Guidelines/2400_LayoutGuidelines.md
@@ -2,7 +2,7 @@
 NOTE: Requires Markdown Extra. See http://michelf.ca/projects/php-markdown/extra/
  --> 
 
-#10. Layout Guidelines
+# 10. Layout Guidelines
 
 ### <a name="av2400"></a> Use a common layout  (AV2400) ![](images/1.png)
 

--- a/Src/Guidelines/9999_ResourcesAndLinks.md
+++ b/Src/Guidelines/9999_ResourcesAndLinks.md
@@ -2,8 +2,8 @@
 NOTE: Requires Markdown Extra. See http://michelf.ca/projects/php-markdown/extra/
  --> 
 
-#A1. Important Resources
-##The companion website
+# A1. Important Resources
+## The companion website
 This document is part of an effort to increase the consciousness with which C# developers do their daily job on a professional level. Therefore I've started a dedicated CodePlex site that can be found at [www.csharpcodingguidelines.com](http://www.csharpcodingguidelines.com).
 
 In addition to the most up to date version of this document, you'll find:
@@ -13,7 +13,7 @@ In addition to the most up to date version of this document, you'll find:
 - [ReSharper](http://www.jetbrains.com/resharper/download/) layout configurations matching the rules in chapter 10.
 - A place to discuss C# coding quality.
 
-##Useful links
+## Useful links
 In addition to the many links provided throughout this document, I'd like to recommend the following books, articles and sites for everyone interested in software quality:
 
 * [Code Complete: A Practical Handbook of Software Construction](http://www.amazon.com/Code-Complete-Practical-Handbook-Construction/dp/0735619670) (Steve McConnel)  


### PR DESCRIPTION
Something must have changed. MD-formatting in GitHub is broken. This PR fixes that.