### PR TITLE
Prefer using a foreach loop over the ForEach method (AV1250)

### DIFF
--- a/Src/Cheatsheet/Cheatsheet.md
+++ b/Src/Cheatsheet/Cheatsheet.md
@@ -60,6 +60,7 @@ NOTE: Requires Markdown Extra. See http://michelf.ca/projects/php-markdown/extra
 * Don’t pass `null` as the sender parameter when raising an event (AV1235)  
 * Use generic constraints if applicable (AV1240)  
 * Evaluate the result of a LINQ expression before returning it (AV1250)  
+* Prefer using a foreach loop over the ForEach method (AV1251)  
 
 <br/>
 **Maintainability**  

--- a/Src/Guidelines/1200_MiscellaneousDesignGuidelines.md
+++ b/Src/Guidelines/1200_MiscellaneousDesignGuidelines.md
@@ -103,3 +103,18 @@ Consider the following code snippet
 	}
 
 Since LINQ queries use deferred execution, returning `query` will actually return the expression tree representing the above query. Each time the caller evaluates this result using a `foreach` cycle or similar, the entire query is re-executed resulting in new instances of `GoldMember` every time. Consequently, you cannot use the `==` operator to compare multiple `GoldMember` instances. Instead, always explicitly evaluate the result of a LINQ query using `ToList()`, `ToArray()` or similar methods.
+
+### <a name="av1251"></a> Prefer using a foreach loop over the ForEach method (AV1251) ![](images/1.png)
+
+The sole purpose of the `ForEach` method is to cause side effects, which violates the functional programming principles that all the other LINQ sequence operators are based upon.
+
+	// Don't
+	customers.ForEach(customer => customer.DisplayName = customer.FirstName + " " + customer.LastName);
+	
+	// Do
+	foreach (var customer in customers)
+	{
+		customer.DisplayName = customer.FirstName + " " + customer.LastName;
+	}
+
+**Exception:** Parellel.ForEach can be used to execute iterations in parallel.


### PR DESCRIPTION
Motivations:
* Eric Lippert is philosophically opposed to the ForEach method
https://blogs.msdn.microsoft.com/ericlippert/2009/05/18/foreach-vs-foreach/
* It blurs the boundary between pure functional code and state-full imperative code
https://blogs.msdn.microsoft.com/ericwhite/2009/04/08/why-i-dont-use-the-foreach-extension-method/
* From a runtime perspective: it is dangerous, unverifiable, yet not a good design
https://blogs.msdn.microsoft.com/mazhou/2011/09/21/why-no-foreach-method-on-ienumerable-interfaces/
* ForEach was omitted from Metro-style apps, because its existence is considered a mistake
https://social.msdn.microsoft.com/Forums/en-US/758f7b98-e3ce-41e5-82a2-109f1df446c2/where-is-listtforeach?forum=winappswithcsharp