### PR TITLE
Various small corrections

### DIFF
--- a/Src/Guidelines/1100_MemberDesignGuidelines.md
+++ b/Src/Guidelines/1100_MemberDesignGuidelines.md
@@ -45,7 +45,7 @@ Returning `null` can be unexpected by the caller. Always return an empty collect
 
 ### <a name="av1137"></a> Define parameters as specific as possible (AV1137) ![](images/2.png)
 
-If your member needs a specific piece of data, define parameters as specific as that and don't take a container object instead. For instance, consider a method that needs a connection string that is exposed through a central `IConfiguration` interface. Rather than taking a dependency on the entire configuration, just define a parameter for the connection string. This not only prevents unnecessary coupling, it also improved maintainability in the long run.
+If your member needs a specific piece of data, define parameters as specific as that and don't take a container object instead. For instance, consider a method that needs a connection string that is exposed through a central `IConfiguration` interface. Rather than taking a dependency on the entire configuration, just define a parameter for the connection string. This not only prevents unnecessary coupling, it also improves maintainability in the long run.
 
 **Note:** An easy trick to remember this guideline is the *Don't ship the truck if you only need a package*.
 

--- a/Src/Guidelines/1200_MiscellaneousDesignGuidelines.md
+++ b/Src/Guidelines/1200_MiscellaneousDesignGuidelines.md
@@ -85,7 +85,7 @@ Consider the following code snippet
 	
 	public IEnumerable GetGoldMemberCustomers()
 	{
-		const decimal GoldMemberThresholdInEuro = 1000000;
+		const decimal GoldMemberThresholdInEuro = 1_000_000;
 		
 		var query = 
 			from customer in db.Customers

--- a/Src/Guidelines/1500_MaintainabilityGuidelines.md
+++ b/Src/Guidelines/1500_MaintainabilityGuidelines.md
@@ -46,13 +46,13 @@ When using partial types and allocating a part per file, name each file after th
 ### <a name="av1510"></a> Use using statements instead of fully qualified type names (AV1510) ![](images/3.png)
 Limit usage of fully qualified type names to prevent name clashing. For example, don't do this:
 
-	var list = new System.Collections.Generic.List();
+	var list = new System.Collections.Generic.List<string>();
 
 Instead, do this:
 
 	using System.Collections.Generic;
 	
-	var list = new List();
+	var list = new List<string>();
 
 If you do need to prevent name clashing, use a `using` directive to assign an alias:
 
@@ -85,15 +85,15 @@ If the value of one constant depends on the value of another, attempt to make th
 ### <a name="av1520"></a> Only use var when the type is very obvious (AV1520) ![](images/1.png)
 Only use `var` as the result of a LINQ query, or if the type is very obvious from the same statement and using it would improve readability. So don't
 
-	var i = 3;									// what type? int? uint? float?
-	var myfoo = MyFactoryMethod.Create("arg");	// Not obvious what base-class or			
-												// interface to expect. Also difficult
-												// to refactor if you can't search for
-												// the class
+	var item = 3;                              // what type? int? uint? float?
+	var myfoo = MyFactoryMethod.Create("arg"); // Not obvious what base-class or			
+	                                           // interface to expect. Also
+	                                           // difficult to refactor if you can't
+	                                           // search for the class
 
 Instead, use `var` like this:
 
-	var q = from order in orders where order.Items > 10 and order.TotalValue > 1000;
+	var query = from order in orders where order.Items > 10 and order.TotalValue > 1000;
 	var repository = new RepositoryFactory.Get();	
 	var list = new ReadOnlyCollection();
 
@@ -136,17 +136,17 @@ Use collection or [dictionary initializers](http://msdn.microsoft.com/en-us/libr
 
 It is usually bad style to compare a `bool`-type expression to `true` or `false`. For example:
 
-	while (condition == false)// wrong; bad style  
-	while (condition != true)// also wrong  
-	while (((condition == true) == true) == true)// where do you stop?  
-	while (condition)// OK
+	while (condition == false) // wrong; bad style  
+	while (condition != true) // also wrong  
+	while (((condition == true) == true) == true) // where do you stop?  
+	while (condition) // OK
 
 ### <a name="av1530"></a> Don't change a loop variable inside a for loop (AV1530) ![](images/2.png)
 Updating the loop variable within the loop body is generally considered confusing, even more so if the loop variable is modified in more than one place.
 
 	for (int index = 0; index < 10; ++index)  
 	{  
-		if (_some condition_)
+		if (someCondition)
 		{
 			index = 11; // Wrong! Use 'break' or 'continue' instead.  
 		}
@@ -155,15 +155,15 @@ Updating the loop variable within the loop body is generally considered confusin
 ### <a name="av1532"></a> Avoid nested loops (AV1532) ![](images/2.png)
 A method that nests loops is more difficult to understand than one with only a single loop. In fact, in most cases nested loops can be replaced with a much simpler LINQ query that uses the `from` keyword twice or more to *join* the data.
 
-### <a name="av1535"></a> Always add a block after keywords such as `if`, `else`, `while`, `for`, `foreach` and `case` (AV1535) ![](images/2.png)
+### <a name="av1535"></a> Always add a block after the keywords `if`, `else`, `do`, `while`, `for`, `foreach` and `case` (AV1535) ![](images/2.png)
 Please note that this also avoids possible confusion in statements of the form:
 
-	if (b1) if (b2) Foo(); else Bar(); // which 'if' goes with the 'else'?
+	if (isActive) if (isVisible) Foo(); else Bar(); // which 'if' goes with the 'else'?
 	
 	// The right way:  
-	if (b1)  
+	if (isActive)  
 	{  
-		if (b2)  
+		if (isVisible)  
 		{  
 			Foo();  
 		}  
@@ -215,7 +215,7 @@ For example:
 		}  
 		else  
 		{  
-			// What should happen when this point is reached? Ignored? If not,   
+			// What should happen when this point is reached? Ignored? If not,
 			// throw an InvalidOperationException.  
 		}  
 	}
@@ -311,7 +311,7 @@ This guideline only applies to overloads that are intended to provide optional a
 	{
 		private string someText;
 		
-	    	public int IndexOf(string phrase)  
+		public int IndexOf(string phrase)  
 		{  
 			return IndexOf(phrase, 0); 
 		}
@@ -329,7 +329,7 @@ This guideline only applies to overloads that are intended to provide optional a
 
 The class `MyString` provides three overloads for the `IndexOf` method, but two of them simply call the one with one more parameter. Notice that the same rule applies to class constructors; implement the most complete overload and call that one from the other overloads using the `this()` operator. Also notice that the parameters with the same name should appear in the same position in all overloads.
 
-**Important:** If you also want to allow derived classes to override these methods, define the most complete overload as a `protected virtual` method that is called by all overloads.
+**Important:** If you also want to allow derived classes to override these methods, define the most complete overload as a non-private `virtual` method that is called by all overloads.
 
 ### <a name="av1553"></a> Only use optional arguments to replace overloads (AV1553) ![](images/1.png)
 The only valid reason for using C# 4.0's optional arguments is to replace the example from rule AV1551 with a single method like:

--- a/Src/Guidelines/1700_NamingGuidelines.md
+++ b/Src/Guidelines/1700_NamingGuidelines.md
@@ -90,7 +90,7 @@ Although technically correct, statements like the following can be confusing:
 
 ### <a name="av1715"></a> Properly name properties  (AV1715) ![](images/2.png)
 - Name properties with nouns, noun phrases, or occasionally adjective phrases. 
-- Name boolean properties with an affirmative phrase. E.g. `CanSeek` instead of `CantSeek`.
+- Name boolean properties with an affirmative phrase. E.g. `CanSeek` instead of `CannotSeek`.
 - Consider prefixing boolean properties with `Is`, `Has`, `Can`, `Allows`, or `Supports`.
 - Consider giving a property the same name as its type. When you have a property that is strongly typed to an enumeration, the name of the property can be the same as the name of the enumeration. For example, if you have an enumeration named `CacheLevel`, a property that returns one of its values can also be named `CacheLevel`.
 

--- a/Src/Guidelines/2200_FrameworkGuidelines.md
+++ b/Src/Guidelines/2200_FrameworkGuidelines.md
@@ -32,26 +32,26 @@ Rather than:
 
 prefer the use of extension methods from the `System.Linq` namespace:
 
-	var query = items.Where(i => i.Length > 0);
+	var query = items.Where(item => item.Length > 0);
 
-Since LINQ queries should be written out over multiple lines for readability, the second example is a bit more readable.
+Since LINQ queries should be written out over multiple lines for readability, the second example is a bit more compact.
 
-### <a name="av2221"></a> Use Lambda expressions instead of delegates  (AV2221) ![](images/2.png)
+### <a name="av2221"></a> Use Lambda expressions instead of anonymous functions  (AV2221) ![](images/2.png)
 
-Lambda expressions provide a much more elegant alternative for anonymous delegates. So instead of:
+Lambda expressions provide a much more elegant alternative for anonymous functions. So instead of:
 
-	Customer customer = Array.Find(customers, delegate(Customer c)
+	Customer customer = Array.Find(customers, delegate(Customer customer)
 	{
-		return c.Name == "Tom";
+		return customer.Name == "Tom";
 	});
 
 use a Lambda expression:
 
-	Customer customer = Array.Find(customers, c => c.Name == "Tom");
+	Customer customer = Array.Find(customers, customer => customer.Name == "Tom");
 
 Or even better:
 
-	var customer = customers.Where(c => c.Name == "Tom");
+	var customer = customers.Where(customer => customer.Name == "Tom").FirstOrDefault();
 
 ### <a name="av2230"></a> Only use the `dynamic` keyword when talking to a dynamic object  (AV2230) ![](images/1.png)
 The `dynamic` keyword has been introduced for working with dynamic languages. Using it introduces a serious performance bottleneck because the compiler has to generate some complex Reflection code.
@@ -69,10 +69,10 @@ Using the new C# 5.0 keywords results in code that can still be read sequentiall
 
 define it like this:
 
-	public async Task GetDataAsync()
+	public async Task<Data> GetDataAsync()
 	{
-	  var result = await MyWebService.FetchDataAsync();
-	  return new Data (result);
+	  string result = await MyWebService.FetchDataAsync();
+	  return new Data(result);
 	}
 
 **Tip:** Even if you need to target .NET Framework 4.0 you can use the `async` and `await` keywords. Simply install the [Async Targeting Pack](http://www.microsoft.com/en-us/download/details.aspx?id=29576).

--- a/Src/Guidelines/2400_LayoutGuidelines.md
+++ b/Src/Guidelines/2400_LayoutGuidelines.md
@@ -8,13 +8,11 @@ NOTE: Requires Markdown Extra. See http://michelf.ca/projects/php-markdown/extra
 
 - Keep the length of each line under 130 characters.
 
-- Use an indentation of 4 whitespaces, and don't use tabs
+- Use an indentation of 4 spaces, and don't use tabs
 
-- Keep one whitespace between keywords like `if` and the expression, but don't add whitespaces after `(` and before `)` such as: `if (condition == null)`.
+- Keep one space between keywords like `if` and the expression, but don't add spaces after `(` and before `)` such as: `if (condition == null)`.
 
-- Add a whitespace around operators like `+`, `-`, `==`, etc.
-
-- Always follow the keywords `if`, `else`, `do`, `while`, `for` and `foreach` with opening and closing braces, even though the language does not require it. 
+- Add a space around operators like `+`, `-`, `==`, etc.
 
 - Always put opening and closing braces on a new line.
 - Don't indent object Initializers and initialize each property on a new line, so use a format like this: 
@@ -45,7 +43,7 @@ NOTE: Requires Markdown Extra. See http://michelf.ca/projects/php-markdown/extra
 		    select product;
 
 - Start the LINQ statement with all the `from` expressions and don't interweave them with restrictions.
-- Add parentheses around every comparison condition, but don't add parentheses around a singular condition. For example `if (!string.IsNullOrEmpty(str) && (str != "new"))`
+- Add parentheses around every binary expression, but don't add parentheses around unary expressions. For example `if (!string.IsNullOrEmpty(str) && (str != "new"))`
 
 - Add an empty line between multi-line statements, between multi-line members, after the closing parentheses, between unrelated code blocks, around the `#region` keyword, and between the `using` statements of different root namespaces.
 


### PR DESCRIPTION
- Spelling errors
- Add digit separators in example
- Fix missing generic type in example
- Correct indents, spacing and prevent scrollbar on GitHub
- Replace single-letter variables in examples with longer names
- Add `do` keyword on AV1535; removed duplicate text in AV2400
- Replace `protected` with non-private because the example contains public virtual member
- Replaced Cant with Cannot (more proper language usage)
- Fix AV2221: `delegates` is wrong terminology; should be anonymous function
- Correct example by adding missing `FirstOrDefault` call.
- Updated return type to be generic task
- Correction: Replaced "whitespace" with "space" (whitespace represents the set of tabs, line breaks, spaces etc) which is not what's intended here.