### PR TITLE
Removed incomplete sentence

### DIFF
--- a/index.md
+++ b/index.md
@@ -26,7 +26,7 @@ excerpt: 'for versions 5.0, 6.0 and 7.0
 {{ my_include | markdownify }}
 
 ## 1.8 Can I create my own version?
-Absolutely. The corresponding [license](https://github.com/dennisdoomen/CSharpGuidelines/blob/master/LICENSE.md) allows you to fork, adapt and distribute that modified version within your organization as long as you refer back to the original version here. It's not required, but you would make me a very happy man if you credit me as the original author. And if you have any great ideas, recommendations or corrections, either submit an issue, or even better, fork the repository and provide me with a pull request. Just run the following command-line to compile the Markdown versions of the guidelines and cheatsheet to self-contained HTML files.
+Absolutely. The corresponding [license](https://github.com/dennisdoomen/CSharpGuidelines/blob/master/LICENSE.md) allows you to fork, adapt and distribute that modified version within your organization as long as you refer back to the original version here. It's not required, but you would make me a very happy man if you credit me as the original author. And if you have any great ideas, recommendations or corrections, either submit an issue, or even better, fork the repository and provide me with a pull request.
 
 <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
 <ins class="adsbygoogle"


### PR DESCRIPTION
Removed the incomplete part about running a command-line to compile the Markdown versions of the guidelines and cheatsheet to self-contained HTML files.