### PR TITLE
List all covered C# versions in title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Coding Guidelines for C# 5.0, 6.0 and 7.0
+Coding Guidelines for C# 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 7.1 and 7.2
 ================
 
 See the landing page at http://www.csharpcodingguidelines.com

--- a/_config.yml
+++ b/_config.yml
@@ -16,10 +16,10 @@ minimal_mistakes_skin    : "default" # "air", "aqua", "contrast", "dark", "dirt"
 
 # Site Settings
 locale                   : "en-US"
-title                    : "C# Coding Guidelines for versions 5.0, 6.0 and 7.0"
+title                    : "C# Coding Guidelines for versions 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 7.1 and 7.2"
 title_separator          : "-"
 name                     : "Dennis Doomen"
-description              : "C# Coding Guidelines for versions 5.0, 6.0 and 7.0"
+description              : "C# Coding Guidelines for versions 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 7.1 and 7.2"
 url                      : "http://csharpcodingguidelines.com/" # the base hostname & protocol for your site e.g. "https://mmistakes.github.io"
 baseurl                  : # the subpath of your site, e.g. "/blog"
 repository               : "dennisdoomen/csharpguidelines" # GitHub username/repo-name e.g. "mmistakes/minimal-mistakes"

--- a/_includes/0001_Introduction.md
+++ b/_includes/0001_Introduction.md
@@ -1,6 +1,6 @@
 ## 1.1. What is this?
 
-This document attempts to provide guidelines (or coding standards if you like) for coding in C# 5.0, 6.0 or 7.0 that are both useful and pragmatic. Of course, if you create such a document you should practice what you preach. So rest assured, these guidelines are representative to what we at [Aviva Solutions](http://www.avivasolutions.nl) do in our day-to-day work. Notice that not all guidelines have a clear rationale. Some of them are simply choices we made at Aviva Solutions. In the end, it doesn't matter what choice you made, as long as you make one and apply it consistently.
+This document attempts to provide guidelines (or coding standards if you like) for coding in C# 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 7.1 or 7.2 that are both useful and pragmatic. Of course, if you create such a document you should practice what you preach. So rest assured, these guidelines are representative to what we at [Aviva Solutions](http://www.avivasolutions.nl) do in our day-to-day work. Notice that not all guidelines have a clear rationale. Some of them are simply choices we made at Aviva Solutions. In the end, it doesn't matter what choice you made, as long as you make one and apply it consistently.
 
 ## 1.2. Why would you use this document?
 

--- a/_pages/0000_CoverAndStyles.md
+++ b/_pages/0000_CoverAndStyles.md
@@ -12,7 +12,7 @@ NOTE: Requires Markdown Extra. See http://michelf.ca/projects/php-markdown/extra
 Coding Guidelines
 </div><br/>
 <div class="subTitle">
-for C# 5.0, 6.0 and 7.0
+for C# 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 7.1 and 7.2
 </div>
 <br/>
 <div class="author">

--- a/_pages/Cheatsheet.md
+++ b/_pages/Cheatsheet.md
@@ -5,7 +5,7 @@ NOTE: Requires Markdown Extra. See http://michelf.ca/projects/php-markdown/extra
 
 <table width="100%">
 <tr>
-<td class="title">Coding Guidelines for C# 5.0, 6.0 and 7.0 Cheat Sheet</td>
+<td class="title">Coding Guidelines for C# 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 7.1 and 7.2 Cheat Sheet</td>
 <td rowspan="2" style="text-align:right">![logo](assets/images/logo.png)</td>
 </tr>
 <tr>
@@ -121,7 +121,7 @@ NOTE: Requires Markdown Extra. See http://michelf.ca/projects/php-markdown/extra
 
 <table width="100%" style="page-break-before: always;">
  <tr>
-  <td class="title">Coding Guidelines for C# 5.0, 6.0 and 7.0 Cheat Sheet</td>
+  <td class="title">Coding Guidelines for C# 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 7.1 and 7.2 Cheat Sheet</td>
   <td markdown="1" rowspan="2" style="text-align:right">![logo](assets/images/logo.png)</td>
  </tr>
  <tr>

--- a/index.md
+++ b/index.md
@@ -14,7 +14,7 @@ header:
   cta_label: "Get the PDF here!"
   cta_url: "https://github.com/dennisdoomen/csharpguidelines/releases/latest"
   caption: ""
-excerpt: 'for versions 5.0, 6.0 and 7.0
+excerpt: 'for versions 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 7.1 and 7.2
  <br /> 
 [![](https://img.shields.io/github/release/dennisdoomen/csharpguidelines.svg?style=for-the-badge&label=Latest)](https://github.com/dennisdoomen/csharpguidelines/releases/latest)
 [![](https://img.shields.io/github/stars/dennisdoomen/csharpguidelines.svg?style=for-the-badge&label=Star)](https://github.com/dennisdoomen/csharpguidelines/stargazers)


### PR DESCRIPTION
Fixes #124.

Additionally I added 7.2, which has been released by now. Not that we have any guidance specific to that version, but at least I have given it some thought. So it's a conscious decision not to have changes for 7.2.