### PR TITLE
Revert: replace underscores with discards

### DIFF
--- a/_pages/1700_NamingGuidelines.md
+++ b/_pages/1700_NamingGuidelines.md
@@ -139,10 +139,10 @@ Suppose you want to define events related to the deletion of an object. Avoid de
 ### <a name="av1738"></a> Prefix an event handler with "On" (AV1738) ![](/assets/images/3.png)
 It is good practice to prefix the method that handles an event with "On". For example, a method that handles the `Closing` event can be named `OnClosing`.
 
-### <a name="av1739"></a> Use an underscore for irrelevant parameters (AV1739) ![](/assets/images/3.png)
-If you use a lambda expression (for instance, to subscribe to an event) and the actual arguments of the event are irrelevant, use discards to make that explicit:
+### <a name="av1739"></a> Use an underscore for irrelevant lambda parameters (AV1739) ![](/assets/images/3.png)
+If you use a lambda expression (for instance, to subscribe to an event) and the actual parameters of the event are irrelevant, use the following convention to make that explicit:
 
-	button.Click += (_, _) => HandleClick();
+	button.Click += (_, __) => HandleClick();
 
 ### <a name="av1745"></a> Group extension methods in a class suffixed with Extensions (AV1745) ![](/assets/images/3.png)
 If the name of an extension method conflicts with another member or extension method, you must prefix the call with the class name. Having them in a dedicated class with the `Extensions` suffix improves readability.


### PR DESCRIPTION
Because the current example does not compile.
Discards can be used at the call site (arguments), but not at declaration site (parameters), which is what happens here.