### PR TITLE
Updated naming to match with Resharper

### DIFF
--- a/_pages/1700_NamingGuidelines.md
+++ b/_pages/1700_NamingGuidelines.md
@@ -53,7 +53,7 @@ In most cases they are a lazy excuse for not defining a clear and intention-reve
 For example, don't use `g_` or `s_` to distinguish static from non-static fields. A method in which it is difficult to distinguish local variables from member fields is generally too big. Examples of incorrect identifier names are: `_currentUser`, `mUserName`, `m_loginTime`.
 
 ### <a name="av1706"></a> Don't use abbreviations (AV1706) ![](/assets/images/2.png)
-For example, use `OnButtonClick` rather than `OnBtnClick`. Avoid single character variable names, such as `i` or `q`. Use `index` or `query` instead.
+For example, use `ButtonOnClick` rather than `BtnOnClick`. Avoid single character variable names, such as `i` or `q`. Use `index` or `query` instead.
 
 **Exceptions:** Use well-known acronyms and abbreviations that are widely accepted or well-known in your work domain. For instance, use acronym `UI` instead of `UserInterface` and abbreviation `Id` instead of `Identity`.
 
@@ -137,7 +137,7 @@ Suppose you want to define events related to the deletion of an object. Avoid de
 - `Deleted`: Occurs when the object is already deleted.
 
 ### <a name="av1738"></a> Prefix an event handler with "On" (AV1738) ![](/assets/images/3.png)
-It is good practice to prefix the method that handles an event with "On". For example, a method that handles the `Closing` event can be named `OnClosing`.
+It is good practice to prefix the method that handles an event with "On". For example, a method that handles its own `Closing` event should be named `OnClosing`. And a method that handles the `Click` event of its `okButton` field should be named `OkButtonOnClick`.
 
 ### <a name="av1739"></a> Use an underscore for irrelevant parameters (AV1739) ![](/assets/images/3.png)
 If you use a lambda expression (for instance, to subscribe to an event) and the actual arguments of the event are irrelevant, use discards to make that explicit:


### PR DESCRIPTION
We have [discussed](https://github.com/dennisdoomen/CSharpGuidelines/pull/45) this before. However it turns out there's been a [bug](https://youtrack.jetbrains.com/issue/RSRP-461586) in Resharper for many years, which prevents users from changing Resharper's default behavior. And a fix is still not implemented nor planned (feel free to upvote the bug report).

So I updated texts to match with the default Resharper settings for now.