### PR TITLE
Fixed broken link to blog in introduction

### DIFF
--- a/_includes/0001_Introduction.md
+++ b/_includes/0001_Introduction.md
@@ -22,7 +22,7 @@ In general, if I have a discussion with a colleague about a smell that this docu
 - Keep It Simple Stupid (a.k.a. KISS): the simplest solution is more than sufficient.
 - You Ain't Gonna Need It (a.k.a. YAGNI): create a solution for the problem at hand, not for the ones you think may happen later on. Can you predict the future?
 - Don't Repeat Yourself (a.k.a. DRY): avoid duplication within a component, a source control repository or  a [bounded context](http://martinfowler.com/bliki/BoundedContext.html), without forgetting the [Rule of Three](http://lostechies.com/derickbailey/2012/10/31/abstraction-the-rule-of-three/) heuristic.
-- The [four principles of object-oriented programming](https://anampiu.github.io/blog/OOP-principles/): encapsulation, abstraction, inheritance and polymorphism.
+- The [four principles of object-oriented programming](https://anampiu.github.io/OOP-principles/): encapsulation, abstraction, inheritance and polymorphism.
 - In general, generated code should not need to comply with coding guidelines. However, if it is possible to modify the templates used for generation, try to make them generate code that complies as much as possible.
 
 Regardless of the elegance of someone's solution, if it's too complex for the ordinary developer, exposes unusual behavior, or tries to solve many possible future issues, it is very likely the wrong solution and needs redesign. The worst response a developer can give you to these principles is: "But it works?". 


### PR DESCRIPTION
Like the title says, the link to the four principles of OOP was broken:
https://anampiu.github.io/blog/OOP-principles/

The blog part of the url is dropped:
https://anampiu.github.io/OOP-principles/