### PR TITLE
Add adjustment for long-running operations in AV1825

### DIFF
--- a/_rules/1825.md
+++ b/_rules/1825.md
@@ -1,7 +1,7 @@
 ---
 rule_id: 1825
 rule_category: performance
-title: Prefer `Task.Run` for CPU-intensive activities
+title: Prefer `Task.Run` or `Task.Factory.StartNew` for CPU-intensive activities
 severity: 1
 ---
-If you do need to execute a CPU bound operation, use `Task.Run` to offload the work to a thread from the Thread Pool. Remember that you have to marshal the result back to your main thread manually.
+If you do need to execute a CPU bound operation, use `Task.Run` to offload the work to a thread from the Thread Pool. For long-running operations use `Task.Factory.StartNew` with `TaskCreationOptions.LongRunning` parameter to create a new thread. Remember that you have to marshal the result back to your main thread manually.


### PR DESCRIPTION
I think that the rule 1825 deserves slight adjustment. If the operation takes too much time to execute, using `Task.Run` could lead to performance degradation and resource leaks as thread pool threads will be unavailable for a long time. A way to overcome this is to create a new thread, which could be done with `Task.Factory.StartNew`, an extended version of `Task.Run` (or the latter is a shortcut for `Task.Factory.StartNew` if we'd follow it chronologically). 