### PR TITLE
Remove 'case' from rule 1535

### DIFF
--- a/_rules/1535.md
+++ b/_rules/1535.md
@@ -2,6 +2,7 @@
 rule_id: 1535
 rule_category: maintainability
 title: Always add a block after the keywords `if`, `else`, `do`, `while`, `for`, `foreach`
+severity: 2
 ---
 Please note that this also avoids possible confusion in statements of the form:
 

--- a/_rules/1535.md
+++ b/_rules/1535.md
@@ -1,8 +1,7 @@
 ---
 rule_id: 1535
 rule_category: maintainability
-title: Always add a block after the keywords `if`, `else`, `do`, `while`, `for`, `foreach` and `case`
-severity: 2
+title: Always add a block after the keywords `if`, `else`, `do`, `while`, `for`, `foreach`
 ---
 Please note that this also avoids possible confusion in statements of the form:
 

--- a/_rules/1536.md
+++ b/_rules/1536.md
@@ -10,22 +10,16 @@ Add a descriptive comment if the `default` block is supposed to be empty. Moreov
 	{  
 		switch (answer)  
 		{  
-			case "no":  
-			{
+			case "no":
 			  Console.WriteLine("You answered with No");  
 			  break;
-			}  
 			  
 			case "yes":
-			{  
 			  Console.WriteLine("You answered with Yes");  
 			  break;
-			}
 			
 			default:  
-			{
 			  // Not supposed to end up here.  
 			  throw new InvalidOperationException("Unexpected answer " + answer);
-			}  
 		}  
 	}


### PR DESCRIPTION
Suggestion is to remove requirement for braces around `case` blocks as defined in rule 1535.

- Personal background: trying to strictly code against the guideline, case-blocks were looking weird with braces. After searching through both company and GitHub repositories, I have found practically no single C# example of case blocks being surrounded with braces. It seems to be absolutely uncommon.

- Technical background: While braces have a direct influence on control flow of `if`, `for`, `foreach` etc., the control flow in a switch/case is defined by control flow keywords (`break`, `return`, `throw` etc.). This is enforced by the compiler - you can not fall through multiple case labels accidently.