### PR TITLE
Remove ICollection<T> as an allowed interface from AV1130

### DIFF
--- a/_rules/1130.md
+++ b/_rules/1130.md
@@ -1,11 +1,9 @@
 ---
 rule_id: 1130
 rule_category: member-design
-title: Return an `IEnumerable<T>` or `ICollection<T>` instead of a concrete collection class
+title: Return interfaces to unchangeable collections
 severity: 2
 ---
-You generally don't want callers to be able to change an internal collection, so don't return arrays, lists or other collection classes directly. Instead, return an `IEnumerable<T>`, or, if the caller must be able to determine the count, an `ICollection<T>`.
-
-**Note:** If you're using .NET 4.5 or higher, you can also use `IReadOnlyCollection<T>`, `IReadOnlyList<T>` or `IReadOnlyDictionary<TKey, TValue>`.
+You generally don't want callers to be able to change an internal collection, so don't return arrays, lists or other collection classes directly. Instead, return an `IEnumerable<T>`, `IReadOnlyCollection<T>`, `IReadOnlyList<T>` or `IReadOnlyDictionary<TKey, TValue>`.
 
 **Exception:** Immutable collections such as `ImmutableArray<T>`, `ImmutableList<T>` and `ImmutableDictionary<TKey, TValue>` prevent modifications from the outside and are thus allowed.


### PR DESCRIPTION
Reasoning: the ICollection<T> interface actually allows one to modify
the collection, which goes against the intention of this guideline. The
reason for this exception was that versions of .NET Framework before 4.5 did not
include immutable collections.

Closes dennisdoomen#215