### PR TITLE
Fix formatting of titles

### DIFF
--- a/Build/default.ps1
+++ b/Build/default.ps1
@@ -105,7 +105,7 @@ task Compile {
 						$ruleIdPrefix = $Matches[2].Trim()
 					}
 
-					$content += "<h3 id=`"${ruleIdPrefix}${ruleId}`">$ruleTitle (${ruleIdPrefix}${ruleId}) <img src=`"assets/images/$ruleSeverity.png`" /></h3>`n"
+					$content += "<div id=`"${ruleIdPrefix}${ruleId}`"></div>### $ruleTitle (${ruleIdPrefix}${ruleId}) <img src=`"assets/images/$ruleSeverity.png`" />`n"
 
 					# Add rule content without Frontmatter
 					$content += ($rule -replace '---\r?\n(.|\r?\n)+?---\r?\n', "")

--- a/_layouts/rule-category.html
+++ b/_layouts/rule-category.html
@@ -7,6 +7,6 @@ layout: single
     {% if rule.custom_prefix != nil  %}
         {% assign full_rule_id = rule.custom_prefix | append: rule.rule_id  %}
     {% endif %}
-    <h3 id="{{ full_rule_id }}">{{ rule.title }} ({{ full_rule_id }}) <img src="/assets/images/{{ rule.severity }}.png" /></h3>
+    <h3 id="{{ full_rule_id }}">{{ rule.title | markdownify | replace: "<p>", "" | replace: "</p>", "" }} ({{ full_rule_id }}) <img src="/assets/images/{{ rule.severity }}.png" /></h3>
     {{ rule.content }}
 {% endfor %}

--- a/assets/js/lunr/lunr-store.js
+++ b/assets/js/lunr/lunr-store.js
@@ -44,7 +44,7 @@ var store = [
     {% assign full_rule_id = site.default_rule_prefix | append: rule.rule_id  %}
     {% assign category_page = site.pages | where: "rule_category", rule.rule_category | first  %}
     {
-      "title": {{ full_rule_id | append: ": " | append: rule.title | jsonify }},
+      "title": {{ full_rule_id | append: ": " | append: rule.title | markdownify | replace: "<p>", "" | replace: "</p>", "" | jsonify }},
       "excerpt":
         {%- if site.search_full_content == true -%}
           {{ rule.content |


### PR DESCRIPTION
Moved the title out of its HTML tag so it gets proper formatting and added a leading div to preserve anchors.

Result when running locally:
![image](https://user-images.githubusercontent.com/10324372/152331802-564b39ee-24ba-4826-b7eb-f4059359741e.png)
![image](https://user-images.githubusercontent.com/10324372/152332012-4060ee62-4162-4fa6-a56a-ceadbc3c40b9.png)


Fixes #209.

/cc @julianbartel Though this seems to work, perhaps there's a better way. I know nearly nothing about the doc generation process here and I'm open to suggestions, so would be great if can chime in and take a look.