### PR TITLE
AV2210: Max warning level depends on TFM and compiler version

### DIFF
--- a/_rules/2210.md
+++ b/_rules/2210.md
@@ -4,4 +4,4 @@ rule_category: dotnet-framework-usage
 title: Build with the highest warning level
 severity: 1
 ---
-Configure the development environment to use **Warning Level 4** for the C# compiler, and enable the option **Treat warnings as errors** . This allows the compiler to enforce the highest possible code quality.
+Configure the development environment to use the highest available warning Level for the C# compiler, and enable the option **Treat warnings as errors**. This allows the compiler to enforce the highest possible code quality.

--- a/_rules/2210.md
+++ b/_rules/2210.md
@@ -4,4 +4,4 @@ rule_category: dotnet-framework-usage
 title: Build with the highest warning level
 severity: 1
 ---
-Configure the development environment to use the highest available warning Level for the C# compiler, and enable the option **Treat warnings as errors**. This allows the compiler to enforce the highest possible code quality.
+Configure the development environment to use the highest available warning level for the C# compiler, and enable the option **Treat warnings as errors**. This allows the compiler to enforce the highest possible code quality.


### PR DESCRIPTION
This PR minimally updates AV2210 so that it is not incorrect anymore. Leaving #234 open to allow for further exploration.