### PR TITLE
Clarified the use of var (AV1520) and supplemented AV1707 (names)

### DIFF
--- a/_rules/1520.md
+++ b/_rules/1520.md
@@ -1,22 +1,34 @@
 ---
 rule_id: 1520
 rule_category: maintainability
-title: Only use `var` when the type is very obvious
+title: Only use `var` when the type is evident
 severity: 1
 ---
-Only use `var` as the result of a LINQ query, or if the type is very obvious from the same statement and using it would improve readability. So don't
+Use `var` for anonymous types (typically resulting from a LINQ query), or if the type is [evident](https://www.jetbrains.com/help/resharper/2021.3/Using_var_Keyword_in_Declarations.html#use-var-when-evident-details).
+Never use `var` for [built-in types](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/built-in-types).
 
-	// what type? int? uint? float?
-	var item = 3;
+Examples:
 
-	// Not obvious what base-class or interface to expect.
-	// Also difficult to refactor if you can't search for the class.
-	var myfoo = MyFactoryMethod.Create("arg");
+	// Projection into anonymous type.
+	var largeOrders =
+		from order in dbContext.Orders
+		where order.Items.Count > 10 && order.TotalAmount > 1000
+		select new { order.Id, order.TotalAmount };
 
-Instead, use `var` like this:
+	// Built-in types.
+	bool isValid = true;
+	string phoneNumber = "(unavailable)";
+	uint pageSize = Math.Max(itemCount, MaxPageSize);
 
-	var query = from order in orders where order.Items > 10 and order.TotalValue > 1000;
-	var repository = new RepositoryFactory.Get();
-	var list = new ReadOnlyCollection();
+	// Types are evident.
+	var customer = new Customer();
+	var invoice = Invoice.Create(customer.Id);
+	var user = sessionCache.Resolve<User>("john.doe@mail.com");
+	var subscribers = new List<Subscriber>();
+	var summary = shoppingBasket.ToOrderSummary();
 
-In all of three above examples it is clear what type to expect. For a more detailed rationale about the advantages and disadvantages of using `var`, read Eric Lippert's [Uses and misuses of implicit typing](https://docs.microsoft.com/en-us/archive/blogs/ericlippert/uses-and-misuses-of-implicit-typing).
+	// All other cases.
+	IQueryable<Order> recentOrders = ApplyFilter(order => order.CreatedAt > DateTime.Now.AddDays(-30));
+	LoggerMessage message = Compose(context);
+	ReadOnlySpan<string> key = ExtractKeyFromPair("email=john.doe@mail.com");
+	IDictionary<Category, Product> productsPerCategory = shoppingBasket.Products.ToDictionary(product => product.Category);

--- a/_rules/1520.md
+++ b/_rules/1520.md
@@ -31,4 +31,5 @@ Examples:
 	IQueryable<Order> recentOrders = ApplyFilter(order => order.CreatedAt > DateTime.Now.AddDays(-30));
 	LoggerMessage message = Compose(context);
 	ReadOnlySpan<string> key = ExtractKeyFromPair("email=john.doe@mail.com");
-	IDictionary<Category, Product> productsPerCategory = shoppingBasket.Products.ToDictionary(product => product.Category);
+	IDictionary<Category, Product> productsPerCategory =
+		shoppingBasket.Products.ToDictionary(product => product.Category);

--- a/_rules/1520.md
+++ b/_rules/1520.md
@@ -7,8 +7,6 @@ severity: 1
 Use `var` for anonymous types (typically resulting from a LINQ query), or if the type is [evident](https://www.jetbrains.com/help/resharper/2021.3/Using_var_Keyword_in_Declarations.html#use-var-when-evident-details).
 Never use `var` for [built-in types](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/built-in-types).
 
-Examples:
-
 	// Projection into anonymous type.
 	var largeOrders =
 		from order in dbContext.Orders

--- a/_rules/1707.md
+++ b/_rules/1707.md
@@ -7,3 +7,4 @@ severity: 2
 - Use functional names. For example, `GetLength` is a better name than `GetInt`.
 - Don't use terms like `Enum`, `Class` or `Struct` in a name.
 - Identifiers that refer to a collection type should have plural names.
+- Don't include the type in variable names, except to avoid clashes with other variables.


### PR DESCRIPTION
AV1520
This PR does not fundamentally change the point of view around `var` usage. But it makes the examples compatible with automated tooling (vanilla Visual Studio, Visual Studio with Resharper, Rider). Automation is not a requirement, but it should at least be possible (which goes for the majority of rules).

Built-in types are always short, so spelling out the type name does not clutter the screen with useless information, which may happen on deeply nested generic types (`IOrderedEnumerable<IGrouping<...>>`).

The "when evident" mode is conservative in nature, only using `var` when definitely obvious and falling back to full type names when unsure or unable to determine. This means that treating `var` usage manually on a case-by-case basis (effectively allowing `var` in more cases than in the automated case) yields more readable code. But at the expense of recurring subjective discussions around `var` usage in PRs, which is a tradeoff every team can make for itself.

AV1707
When using `var`, some developers tend to suffix each variable name with its type, which is an anti-pattern (similar to Hungarian notation). Because this manual effort deteriorates over time, similar to outdated documentation that states the obvious. When the type changes due to refactorings elsewhere, you'll need to remember to also rename the affected variables, which is often forgotten, and then the code becomes misleading. Therefore it is preferred to rely on type information that gets validated by the compiler.
