### PR TITLE
Added `IQueryable<T>` to AV1130

### DIFF
--- a/_rules/1130.md
+++ b/_rules/1130.md
@@ -4,6 +4,6 @@ rule_category: member-design
 title: Return interfaces to unchangeable collections
 severity: 2
 ---
-You generally don't want callers to be able to change an internal collection, so don't return arrays, lists or other collection classes directly. Instead, return an `IEnumerable<T>`, `IAsyncEnumerable<T>`, `IReadOnlyCollection<T>`, `IReadOnlyList<T>`, `IReadOnlySet<T>` or `IReadOnlyDictionary<TKey, TValue>`.
+You generally don't want callers to be able to change an internal collection, so don't return arrays, lists or other collection classes directly. Instead, return an `IEnumerable<T>`, `IAsyncEnumerable<T>`, `IQueryable<T>`, `IReadOnlyCollection<T>`, `IReadOnlyList<T>`, `IReadOnlySet<T>` or `IReadOnlyDictionary<TKey, TValue>`.
 
 **Exception:** Immutable collections such as `ImmutableArray<T>`, `ImmutableList<T>` and `ImmutableDictionary<TKey, TValue>` prevent modifications from the outside and are thus allowed.


### PR DESCRIPTION
Related to the discussion at https://github.com/bkoelman/CSharpGuidelinesAnalyzer/issues/129.