### PR TITLE
Add AV0112: Apply the Principle of Least Surprise

### DIFF
--- a/_rules/0112.md
+++ b/_rules/0112.md
@@ -13,4 +13,4 @@ This principle manifests in many ways:
 - Follow established conventions for your language, framework and domain.
 - Don't deviate from common patterns without a compelling reason.
 
-When in doubt, ask: "Would a reasonably experienced developer expect this behavior from this name and signature?"
+When in doubt, ask yourself: "Would a reasonably experienced developer expect this behavior from this name and signature?"

--- a/_rules/0112.md
+++ b/_rules/0112.md
@@ -1,0 +1,16 @@
+---
+rule_id: 0112
+rule_category: general
+title: Apply the Principle of Least Surprise
+severity: 1
+---
+Choose solutions that are intuitive and predictable. A developer reading your code should never be surprised by what a method does, how a type is named, or what side effects an operation has.
+
+This principle manifests in many ways:
+
+- Name things so that the name fully describes what they do, without requiring the reader to look at the implementation.
+- Avoid side effects in properties and methods that appear to only read state.
+- Follow established conventions for your language, framework and domain.
+- Don't deviate from common patterns without a compelling reason.
+
+When in doubt, ask: "Would a reasonably experienced developer expect this behavior from this name and signature?"


### PR DESCRIPTION
This PR adds guideline AV0112.

It was split out of #298 so the change can be reviewed independently.

Files:
- _rules/0112.md

Part of the replacement for #298.