### PR TITLE
Add AV0130: Apply the four pillars of object-oriented programming

### DIFF
--- a/_rules/0130.md
+++ b/_rules/0130.md
@@ -1,0 +1,13 @@
+---
+rule_id: 0130
+rule_category: general
+title: Apply the three pillars of object-oriented programming
+severity: 2
+---
+Object-oriented design rests on three fundamental concepts. Understanding and applying them correctly is essential to writing maintainable code:
+
+- **Encapsulation**: hide implementation details behind a well-defined interface. Expose only what callers need, and protect internal invariants.
+- **Abstraction**: model the essential characteristics of a concept, ignoring irrelevant details. Good abstractions hide complexity and provide stable, meaningful interfaces.
+- **Inheritance**: share behavior by forming "is-a" relationships between types. Use sparingly — prefer composition when the relationship is primarily about code reuse rather than substitutability (see [AV0110](/general-guidelines/#AV0110)).
+
+These are tools, not goals. Apply them where they add clarity and maintainability.

--- a/_rules/0130.md
+++ b/_rules/0130.md
@@ -1,13 +1,14 @@
 ---
 rule_id: 0130
 rule_category: general
-title: Apply the three pillars of object-oriented programming
+title: Apply the four pillars of object-oriented programming
 severity: 2
 ---
-Object-oriented design rests on three fundamental concepts. Understanding and applying them correctly is essential to writing maintainable code:
+Object-oriented design rests on four fundamental concepts. Understanding and applying them correctly is essential to writing maintainable code:
 
-- **Encapsulation**: hide implementation details behind a well-defined interface. Expose only what callers need, and protect internal invariants.
+- **Encapsulation**: hide implementation details behind a well-defined interface. Expose only what callers need, and protect internal invariants (see [AV1025](#{{ site.default_rule_prefix }}1025) and [AV1026](#{{ site.default_rule_prefix }}1026)).
 - **Abstraction**: model the essential characteristics of a concept, ignoring irrelevant details. Good abstractions hide complexity and provide stable, meaningful interfaces.
-- **Inheritance**: share behavior by forming "is-a" relationships between types. Use sparingly — prefer composition when the relationship is primarily about code reuse rather than substitutability (see [AV0110](/general-guidelines/#AV0110)).
+- **Inheritance**: share behavior by forming "is-a" relationships between types. Use sparingly — prefer composition when the relationship is primarily about code reuse rather than substitutability (see [AV0110](#{{ site.default_rule_prefix }}0110)).
+- **Polymorphism**: let objects of different types be treated through a common interface. Prefer polymorphism over type-checking and casting (see [AV1011](#{{ site.default_rule_prefix }}1011) and [AV1013](#{{ site.default_rule_prefix }}1013)).
 
 These are tools, not goals. Apply them where they add clarity and maintainability.


### PR DESCRIPTION
This PR adds guideline AV0130.

It was split out of #298 so the change can be reviewed independently.

Files:
- _rules/0130.md

Part of the replacement for #298.