### PR TITLE
Add AV1002: Only pass things to a constructor that most or all members need

### DIFF
--- a/_rules/1002.md
+++ b/_rules/1002.md
@@ -1,0 +1,9 @@
+---
+rule_id: 1002
+rule_category: class-design
+title: Only pass things to a constructor that most or all members need
+severity: 3
+---
+A constructor exists to put the object in a valid, usable state. If a dependency or value is only used by one or two members out of many, passing it through the constructor forces every caller to provide something that is barely relevant to the object as a whole. This is a strong signal that those members belong in a separate, more focused class (see [AV1000](#{{ site.default_rule_prefix }}1000)).
+
+**Exception:** Cross-cutting concerns such as logging or clock abstractions are often needed broadly and may reasonably be injected through the constructor even if not every member uses them directly.

--- a/_rules/1002.md
+++ b/_rules/1002.md
@@ -1,7 +1,7 @@
 ---
 rule_id: 1002
 rule_category: class-design
-title: Only pass things to a constructor that most or all members need
+title: Only include parameters in a constructor that most or all members need
 severity: 3
 ---
 A constructor exists to put the object in a valid, usable state. If a dependency or value is only used by one or two members out of many, passing it through the constructor forces every caller to provide something that is barely relevant to the object as a whole. This is a strong signal that those members belong in a separate, more focused class (see [AV1000](#{{ site.default_rule_prefix }}1000)).

--- a/_rules/1002.md
+++ b/_rules/1002.md
@@ -4,6 +4,10 @@ rule_category: class-design
 title: Only include parameters in a constructor that most or all members need
 severity: 3
 ---
-A constructor exists to put the object in a valid, usable state. If a dependency or value is only used by one or two members out of many, passing it through the constructor forces every caller to provide something that is barely relevant to the object as a whole. This is a strong signal that those members belong in a separate, more focused class (see [AV1000](#{{ site.default_rule_prefix }}1000)).
+A constructor exists to put the object in a valid, usable state. If a value or dependency is only needed by a single method, consider passing it as a method parameter instead. This keeps the constructor focused and avoids forcing every caller to provide something that is barely relevant to the object as a whole.
 
-**Exception:** Cross-cutting concerns such as logging or clock abstractions are often needed broadly and may reasonably be injected through the constructor even if not every member uses them directly.
+For `internal` types, this is straightforward to apply: since callers are within the same codebase, moving a rarely-used parameter from the constructor to a method parameter is a low-risk refactoring.
+
+For `public` types, be more conservative. Removing a constructor parameter is a breaking API change, so consider whether the dependency is likely to be needed by future members before deciding to keep it out of the constructor.
+
+**Exception:** Cross-cutting concerns such as logging or a clock abstraction (`TimeProvider`) are often needed broadly and may reasonably be injected through the constructor even if not every member uses them directly.


### PR DESCRIPTION
This PR adds guideline AV1002.

It was split out of #298 so the change can be reviewed independently.

Files:
- _rules/1002.md

Part of the replacement for #298.