### PR TITLE
Add AV1028: Don't create a record with a constructor that takes more than 4 parameters

### DIFF
--- a/_rules/1028.md
+++ b/_rules/1028.md
@@ -1,0 +1,27 @@
+---
+rule_id: 1028
+rule_category: class-design
+title: Don't create a record with a constructor that takes more than 4 parameters
+severity: 2
+---
+Records are designed to be concise value-like types. A record that requires more than 4 constructor parameters is a signal that either it is doing too much, or that a positional constructor is the wrong choice.
+
+Instead, define the record using properties:
+
+```csharp
+// Avoid
+public record Address(string Street, string City, string PostalCode, string Country, string State, string Building);
+
+// Prefer
+public record Address
+{
+    public required string Street { get; init; }
+    public required string City { get; init; }
+    public required string PostalCode { get; init; }
+    public required string Country { get; init; }
+    public string? State { get; init; }
+    public string? Building { get; init; }
+}
+```
+
+Using properties also allows partial initialization and makes call sites more readable, because each value is explicitly named.


### PR DESCRIPTION
This PR adds guideline AV1028.

It was split out of #298 so the change can be reviewed independently.

Files:
- _rules/1028.md

Part of the replacement for #298.