### PR TITLE
Add AV1032: Consider a delegate instead of an interface with a single method

### DIFF
--- a/_rules/1032.md
+++ b/_rules/1032.md
@@ -1,0 +1,33 @@
+---
+rule_id: 1032
+rule_category: class-design
+title: Consider a delegate instead of an interface with a single method
+severity: 3
+---
+An interface with a single method is essentially a named function signature. Unless the abstraction carries domain meaning or will gain more members in the future, a delegate is simpler and avoids the ceremony of a full interface definition and its implementations.
+
+```csharp
+// Instead of this single-method interface...
+public interface IOrderFilter
+{
+    bool Matches(Order order);
+}
+
+// ...consider a delegate
+public delegate bool OrderFilter(Order order);
+
+// Or simply use Func<T, bool>
+public void Process(IEnumerable<Order> orders, Func<Order, bool> filter)
+{
+    foreach (var order in orders.Where(filter))
+    {
+        // ...
+    }
+}
+```
+
+Prefer a single-method interface when:
+- The abstraction has domain meaning beyond "a function".
+- Implementations need to carry state.
+- The interface is a well-known contract that consumers will implement (e.g. in a public API).
+- The interface may gain additional members in the future.

--- a/_rules/1032.md
+++ b/_rules/1032.md
@@ -1,10 +1,10 @@
 ---
 rule_id: 1032
 rule_category: class-design
-title: Consider a delegate instead of an interface with a single method
+title: Consider a named delegate instead of an interface with a single method
 severity: 3
 ---
-An interface with a single method is essentially a named function signature. Unless the abstraction carries domain meaning or will gain more members in the future, a delegate is simpler and avoids the ceremony of a full interface definition and its implementations.
+An interface with a single method is essentially a named function signature. Unless you know that this interface will gain more members in the near future, a delegate is simpler, creates a more loosely coupled abstraction, and you don't need mocking frameworks to provide a value in tests. 
 
 ```csharp
 // Instead of this single-method interface...
@@ -17,17 +17,23 @@ public interface IOrderFilter
 public delegate bool OrderFilter(Order order);
 
 // Or simply use Func<T, bool>
-public void Process(IEnumerable<Order> orders, Func<Order, bool> filter)
+public void Process(IEnumerable<Order> orders, OrderFilter filter)
 {
     foreach (var order in orders.Where(filter))
     {
         // ...
     }
 }
+
+// In a test you can pass any method or lambda that matches the signature.
+Process(orders, order => order.Value > 10000);
 ```
 
 Prefer a single-method interface when:
-- The abstraction has domain meaning beyond "a function".
-- Implementations need to carry state.
-- The interface is a well-known contract that consumers will implement (e.g. in a public API).
-- The interface may gain additional members in the future.
+- Implementations need to carry state
+- The interface is supposed to provide a strong well-defined contract like `IEquatable`, `IDisposable`
+- You want to use Default Interface Methods
+- The interface is expected to gain additional members in the near future
+
+**Note:** A simple lambda is technically compatible with a named delegate, but a named delegate offers better discoverability: find-usages, go-to-definition, and DI registration all work the same as with an interface.
+


### PR DESCRIPTION
This PR adds guideline AV1032.

It was split out of #298 so the change can be reviewed independently.

Files:
- _rules/1032.md

Part of the replacement for #298.