### PR TITLE
Add AV1035: Use primary constructors when they improve readability

### DIFF
--- a/_rules/1035.md
+++ b/_rules/1035.md
@@ -1,0 +1,35 @@
+---
+rule_id: 1035
+rule_category: class-design
+title: Use primary constructors when they improve readability
+severity: 3
+---
+C# 12 introduced primary constructors, which let you declare constructor parameters directly on the class or record declaration. This reduces boilerplate when the constructor mainly exists to assign dependencies to fields or auto-properties.
+
+```csharp
+// Before primary constructors
+public class OrderService
+{
+    private readonly IOrderRepository repository;
+
+    public OrderService(IOrderRepository repository)
+    {
+        this.repository = repository;
+    }
+}
+
+// With primary constructors
+public class OrderService(IOrderRepository repository)
+{
+    public async Task<Order> GetOrderAsync(Guid id)
+        => await repository.GetByIdAsync(id);
+}
+```
+
+Prefer primary constructors when:
+- The constructor only captures dependencies or configuration values.
+- There is no complex initialization logic that would benefit from a named constructor body.
+
+Avoid primary constructors when:
+- The constructor contains validation or non-trivial initialization logic.
+- The parameter names would be confused with members (the parameter is in scope throughout the entire class body).

--- a/_rules/1035.md
+++ b/_rules/1035.md
@@ -1,7 +1,7 @@
 ---
 rule_id: 1035
 rule_category: class-design
-title: Use primary constructors when they improve readability
+title: Prefer primary constructors over regular constructors
 severity: 3
 ---
 C# 12 introduced primary constructors, which let you declare constructor parameters directly on the class or record declaration. This reduces boilerplate when the constructor mainly exists to assign dependencies to fields or auto-properties.
@@ -31,5 +31,4 @@ Prefer primary constructors when:
 - There is no complex initialization logic that would benefit from a named constructor body.
 
 Avoid primary constructors when:
-- The constructor contains validation or non-trivial initialization logic.
-- The parameter names would be confused with members (the parameter is in scope throughout the entire class body).
+- The constructor contains parameter validation or non-trivial initialization logic.


### PR DESCRIPTION
This PR adds guideline AV1035.

It was split out of #298 so the change can be reviewed independently.

Files:
- _rules/1035.md

Part of the replacement for #298.