### PR TITLE
Add AV1145: Use extension members to add behavior without modifying the original type

### DIFF
--- a/_rules/1145.md
+++ b/_rules/1145.md
@@ -1,0 +1,28 @@
+---
+rule_id: 1145
+rule_category: member-design
+title: Use extension members to add behavior without modifying the original type
+severity: 3
+---
+C# 14 introduced extension members (also called extension blocks), which allow you to add properties, methods and other members to existing types without modifying the original type definition.
+
+```csharp
+// C# 14 extension block
+extension(Order order)
+{
+    public bool IsOverdue => order.DueDate < DateTimeOffset.UtcNow && !order.IsCompleted;
+
+    public void MarkAsShipped(DateTimeOffset shippedAt)
+    {
+        order.Status = OrderStatus.Shipped;
+        order.ShippedAt = shippedAt;
+    }
+}
+```
+
+Use extension members when:
+- You want to add behavior to a type you don't own (e.g. from a third-party library or the BCL).
+- You want to keep domain logic close to the type it operates on without polluting the type's own definition.
+- You are adding utility methods that are only relevant in a specific layer or context.
+
+Don't use extension members to work around encapsulation or to add behavior that logically belongs in the type itself.

--- a/_rules/1145.md
+++ b/_rules/1145.md
@@ -25,4 +25,4 @@ Use extension members when:
 - You want to keep domain logic close to the type it operates on without polluting the type's own definition.
 - You are adding utility methods that are only relevant in a specific layer or context.
 
-Don't use extension members to work around encapsulation or to add behavior that logically belongs in the type itself.
+Don't use extension members if you can add that method directly to the type.


### PR DESCRIPTION
This PR adds guideline AV1145.

It was split out of #298 so the change can be reviewed independently.

Files:
- _rules/1145.md

Part of the replacement for #298.