### PR TITLE
Add AV1150: Avoid local functions

### DIFF
--- a/_rules/1150.md
+++ b/_rules/1150.md
@@ -1,0 +1,14 @@
+---
+rule_id: 1150
+rule_category: member-design
+title: Avoid local functions
+severity: 3
+---
+Local functions (methods defined inside another method) can be useful in rare cases, but they often obscure the structure of a method, make unit testing harder, and are easy to misuse as a way to avoid proper decomposition.
+
+Avoid local functions when:
+- The behavior could be extracted into a private method on the class.
+- The logic is complex enough to warrant its own test.
+- The local function captures outer variables in a non-obvious way.
+
+Local functions are acceptable for small, single-use helper logic such as recursive helpers or iterator implementation details, where extracting to a method would require passing many parameters.

--- a/_rules/1150.md
+++ b/_rules/1150.md
@@ -4,7 +4,7 @@ rule_category: member-design
 title: Avoid local functions
 severity: 3
 ---
-Local functions (methods defined inside another method) can be useful in rare cases, but they often obscure the structure of a method, make unit testing harder, and are easy to misuse as a way to avoid proper decomposition.
+Local functions (methods defined inside another method) can be useful in rare cases, but they often obscure a method's structure and make unit testing harder. Their usage often indicates a lack of proper decomposition.
 
 Local functions can be a good fit for:
 - Trivial private recursion.

--- a/_rules/1150.md
+++ b/_rules/1150.md
@@ -6,9 +6,4 @@ severity: 3
 ---
 Local functions (methods defined inside another method) can be useful in rare cases, but they often obscure the structure of a method, make unit testing harder, and are easy to misuse as a way to avoid proper decomposition.
 
-Avoid local functions when:
-- The behavior could be extracted into a private method on the class.
-- The logic is complex enough to warrant its own test.
-- The local function captures outer variables in a non-obvious way.
-
 Local functions are acceptable for small, single-use helper logic such as recursive helpers or iterator implementation details, where extracting to a method would require passing many parameters.

--- a/_rules/1150.md
+++ b/_rules/1150.md
@@ -6,4 +6,7 @@ severity: 3
 ---
 Local functions (methods defined inside another method) can be useful in rare cases, but they often obscure the structure of a method, make unit testing harder, and are easy to misuse as a way to avoid proper decomposition.
 
-Local functions are acceptable for small, single-use helper logic such as recursive helpers or iterator implementation details, where extracting to a method would require passing many parameters.
+Local functions can be a good fit for:
+- Trivial private recursion.
+- Iterator implementations (validate inputs upfront in the containing method, instead of during deferred execution).
+- Extracting to a method would require passing many parameters that are otherwise captured.


### PR DESCRIPTION
This PR adds guideline AV1150.

It was split out of #298 so the change can be reviewed independently.

Files:
- _rules/1150.md

Part of the replacement for #298.