### PR TITLE
Add AV1155: Use the `field` keyword in auto-properties when additional logic is needed

### DIFF
--- a/_rules/1155.md
+++ b/_rules/1155.md
@@ -4,7 +4,7 @@ rule_category: member-design
 title: Use the `field` keyword in auto-properties when additional logic is needed
 severity: 3
 ---
-C# 14 introduced the `field` keyword, which lets you access the compiler-generated backing field of an auto-property without having to declare a manual field. This keeps the property concise while still allowing validation or transformation logic.
+C# 14 introduced the `field` keyword, which provides access to the underlying storage of a property without the need to declare a private field. This eliminates boilerplate while still allowing validation or transformation logic. Furthermore, it protects against other members modifying the underlying value, which breaks encapsulation.
 
 ```csharp
 // Before C# 14: required a manual backing field

--- a/_rules/1155.md
+++ b/_rules/1155.md
@@ -1,0 +1,30 @@
+---
+rule_id: 1155
+rule_category: member-design
+title: Use the `field` keyword in auto-properties when additional logic is needed
+severity: 3
+---
+C# 14 introduced the `field` keyword, which lets you access the compiler-generated backing field of an auto-property without having to declare a manual field. This keeps the property concise while still allowing validation or transformation logic.
+
+```csharp
+// Before C# 14: required a manual backing field
+private string _name = string.Empty;
+public string Name
+{
+    get => _name;
+    set => _name = value?.Trim() ?? throw new ArgumentNullException(nameof(value));
+}
+
+// With C# 14: use the field keyword
+public string Name
+{
+    get;
+    set => field = value?.Trim() ?? throw new ArgumentNullException(nameof(value));
+}
+```
+
+Use the `field` keyword when:
+- You need getter or setter logic that goes beyond a simple assignment, but don't want to sacrifice the clarity of an auto-property.
+- Adding a backing field would add noise without adding meaning.
+
+Don't use `field` when the backing field itself carries meaning (e.g. needs its own name or XML documentation).

--- a/_rules/1155.md
+++ b/_rules/1155.md
@@ -8,7 +8,7 @@ C# 14 introduced the `field` keyword, which provides access to the underlying st
 
 ```csharp
 // Before C# 14: required a manual backing field
-private string _name = string.Empty;
+private string name = string.Empty;
 public string Name
 {
     get => _name;

--- a/_rules/1155.md
+++ b/_rules/1155.md
@@ -11,8 +11,8 @@ C# 14 introduced the `field` keyword, which provides access to the underlying st
 private string name = string.Empty;
 public string Name
 {
-    get => _name;
-    set => _name = value?.Trim() ?? throw new ArgumentNullException(nameof(value));
+    get => name;
+    set => name = value?.Trim() ?? throw new ArgumentNullException(nameof(value));
 }
 
 // With C# 14: use the field keyword

--- a/_rules/1155.md
+++ b/_rules/1155.md
@@ -8,18 +8,26 @@ C# 14 introduced the `field` keyword, which provides access to the underlying st
 
 ```csharp
 // Before C# 14: required a manual backing field
-private string name = string.Empty;
-public string Name
+private int maxLength;
+public int MaxLength
 {
-    get => name;
-    set => name = value?.Trim() ?? throw new ArgumentNullException(nameof(value));
+    get => maxLength;
+    set
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(value, 0);
+        maxLength = value;
+    }
 }
 
 // With C# 14: use the field keyword
-public string Name
+public int MaxLength
 {
     get;
-    set => field = value?.Trim() ?? throw new ArgumentNullException(nameof(value));
+    set
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(value, 0);
+        field = value;
+    }
 }
 ```
 


### PR DESCRIPTION
This PR adds guideline AV1155.

It was split out of #298 so the change can be reviewed independently.

Files:
- _rules/1155.md

Part of the replacement for #298.