### PR TITLE
Add AV1578: Align projects with deployment units, not architectural layers

### DIFF
--- a/_rules/1578.md
+++ b/_rules/1578.md
@@ -1,0 +1,34 @@
+---
+rule_id: 1578
+rule_category: maintainability
+title: Align projects and folders with deployment units, not architectural layers
+severity: 2
+---
+A common but problematic project structure organizes code into layer-based projects such as `MyApp.Domain`, `MyApp.Application`, `MyApp.Infrastructure` and `MyApp.Web`. While this separation has academic appeal, it tends to create artificial coupling, makes it harder to split off bounded contexts later, and forces cross-cutting concerns into awkward locations.
+
+Instead, organize projects or folders around deployment units and bounded contexts:
+
+```text
+// Avoid (layer-based)
+MyApp.Domain
+MyApp.Application
+MyApp.Infrastructure
+MyApp.Web
+
+// Prefer (deployment-unit / bounded-context-based)
+MyApp.Orders          // all layers for the Orders context
+MyApp.Catalog         // all layers for the Catalog context
+MyApp.Notifications   // a deployable notification service
+MyApp.Web             // host project, composes the above
+MyApp.Common          // Code that is complicated enough to avoid duplicating (see also [{{ site.default_rule_prefix }}1580](/maintainability-guidelines#{{ site.default_rule_prefix }}1580))
+```
+
+This approach:
+- Makes each project independently deployable or extractable.
+- Keeps cohesive code together: the model, business logic and persistence for a given feature are in the same project.
+- Reduces the need for cross-project dependencies within a single bounded context.
+- Makes room for keeping complicated generic code
+- Allows using projects or folders to represent functional boundaries
+
+
+**Note:** A thin host project (`MyApp.Web`, `MyApp.Api`) that composes all contexts is still appropriate, and shared infrastructure utilities can live in a `MyApp.Infrastructure.Shared` project when genuinely reused.


### PR DESCRIPTION
This PR adds guideline AV1578.

It was split out of #298 so the change can be reviewed independently.

Files:
- _rules/1578.md

Part of the replacement for #298.