### PR TITLE
Add AV1585: Make properties required when they must be set during initialization

### DIFF
--- a/_rules/1585.md
+++ b/_rules/1585.md
@@ -1,0 +1,34 @@
+---
+rule_id: 1585
+rule_category: maintainability
+title: Make properties required when they must be set during initialization
+severity: 2
+---
+C# 11 introduced the `required` modifier for properties and fields. When a property is marked `required`, the compiler enforces that any object initializer sets it, preventing accidentally uninitialized state without needing a constructor parameter.
+
+```csharp
+// Without required: easy to forget a property
+var order = new Order { TotalAmount = 99.95m }; // OrderId is silently left as default
+
+// With required: the compiler will error if OrderId is not set
+public class Order
+{
+    public required Guid OrderId { get; init; }
+    public required decimal TotalAmount { get; init; }
+    public string? Notes { get; init; }
+}
+
+var order = new Order
+{
+    OrderId = Guid.NewGuid(),
+    TotalAmount = 99.95m
+    // Notes is optional, so it's fine to omit
+};
+```
+
+Use `required` when:
+- A property must always be set to a meaningful value for the object to be valid.
+- You want to avoid a parameterized constructor but still enforce initialization.
+- The type is a DTO or a record-like class used with object initializers.
+
+**Note:** `required` and `init`-only properties are complementary. Combine them (`public required string Name { get; init; }`) to enforce both initialization and immutability.

--- a/_rules/1585.md
+++ b/_rules/1585.md
@@ -13,9 +13,9 @@ var order = new Order { TotalAmount = 99.95m }; // OrderId is silently left as d
 // With required: the compiler will error if OrderId is not set
 public class Order
 {
-    public required Guid OrderId { get; init; }
-    public required decimal TotalAmount { get; init; }
-    public string? Notes { get; init; }
+    public required Guid OrderId { get; set; }
+    public required decimal TotalAmount { get; set; }
+    public string? Notes { get; set; }
 }
 
 var order = new Order
@@ -28,7 +28,6 @@ var order = new Order
 
 Use `required` when:
 - A property must always be set to a meaningful value for the object to be valid.
-- You want to avoid adding a constructor but still enforce initialization.
 - The type is a DTO or a record-like class used with object initializers.
 
 **Note:** `required` and `init`-only properties are complementary. Combine them (`public required string Name { get; init; }`) to enforce both initialization and immutability.

--- a/_rules/1585.md
+++ b/_rules/1585.md
@@ -28,7 +28,7 @@ var order = new Order
 
 Use `required` when:
 - A property must always be set to a meaningful value for the object to be valid.
-- You want to avoid a parameterized constructor but still enforce initialization.
+- You want to avoid adding a constructor but still enforce initialization.
 - The type is a DTO or a record-like class used with object initializers.
 
 **Note:** `required` and `init`-only properties are complementary. Combine them (`public required string Name { get; init; }`) to enforce both initialization and immutability.


### PR DESCRIPTION
This PR adds guideline AV1585.

It was split out of #298 so the change can be reviewed independently.

Files:
- _rules/1585.md

Part of the replacement for #298.