### PR TITLE
Add AV1600: Use short concise functional test names

### DIFF
--- a/_rules/1600.md
+++ b/_rules/1600.md
@@ -1,0 +1,22 @@
+---
+rule_id: 1600
+rule_category: testability
+title: Use short concise functional test names
+severity: 2
+---
+A test name should describe the behavior being verified in plain language, not the implementation detail being exercised. It should read like a sentence that a non-developer can understand, preferably in the present tense. In other words, without words like "should" and "would".
+
+```csharp
+// Avoid
+[Fact]
+public void TestCalculations1() { ... }
+
+[Fact]
+public void CalculateTotal_WhenDiscountIsApplied_ShouldReturnReducedAmount() { ... }
+
+// Prefer
+[Fact]
+public void Total_is_reduced_when_a_discount_is_applied() { ... }
+```
+
+Use underscores to separate words if your test framework supports it. Keep names short enough to fit on one line, but long enough to communicate intent without reading the test body.


### PR DESCRIPTION
This PR adds guideline AV1600.

It was split out of #298 so the change can be reviewed independently.

Files:
- _rules/1600.md

Part of the replacement for #298.