### PR TITLE
Add AV1620: Test reusable components separately from their consumers

### DIFF
--- a/_rules/1620.md
+++ b/_rules/1620.md
@@ -1,0 +1,24 @@
+---
+rule_id: 1620
+rule_category: testability
+title: Test reusable components separately from their consumers
+severity: 2
+---
+Components that are designed to be reused (utility classes, validators, domain services, extension methods) deserve their own focused test suite. Don't rely on tests of the consumer to cover the reusable component.
+
+Benefits:
+- Failures in the component are reported directly against it, not buried in a consumer's tests.
+- The component's behavior is documented independently.
+- Refactoring the consumer doesn't accidentally reduce coverage of the shared component.
+
+```csharp
+// Don't rely on OrderServiceSpecs to cover EmailValidator
+public class EmailValidatorSpecs
+{
+    [Fact]
+    public void Rejects_an_address_without_at_sign() { ... }
+
+    [Fact]
+    public void Accepts_a_standard_email_address() { ... }
+}
+```

--- a/_rules/1620.md
+++ b/_rules/1620.md
@@ -4,7 +4,7 @@ rule_category: testability
 title: Test reusable components separately from their consumers
 severity: 2
 ---
-Components that are designed to be reused (utility classes, validators, domain services, extension methods) deserve their own focused test suite. Don't rely on tests of the consumer to cover the reusable component.
+Components that are designed to be reused (serializers, validators, domain services, extension methods) deserve their own focused test suite. Don't rely on tests of the consumer to cover the reusable component.
 
 Benefits:
 - Failures in the component are reported directly against it, not buried in a consumer's tests.


### PR DESCRIPTION
This PR adds guideline AV1620.

It was split out of #298 so the change can be reviewed independently.

Files:
- _rules/1620.md

Part of the replacement for #298.