### PR TITLE
Add AV1622: Test concrete implementations as part of a larger integration scope

### DIFF
--- a/_rules/1622.md
+++ b/_rules/1622.md
@@ -1,0 +1,25 @@
+---
+rule_id: 1622
+rule_category: testability
+title: Test concrete implementations as part of a larger integration scope
+severity: 2
+---
+Internal implementation details that are not individually reusable are best tested through the component that uses them, not in isolation. Testing every private helper class independently ties your test suite to the internal structure and makes refactoring harder.
+
+```csharp
+// Avoid testing internal infrastructure directly
+public class SqlOrderRepositoryInternalsSpecs
+{
+    [Fact]
+    public void BuildsCorrectSqlQuery() { ... } // fragile implementation detail
+}
+
+// Prefer testing through the public contract
+public class OrderRepositorySpecs
+{
+    [Fact]
+    public void Retrieves_an_order_by_id() { ... } // observable behavior
+}
+```
+
+Reserve unit tests for logic that is independently reusable or complex enough to warrant isolation. For the rest, integration or component tests through the public API provide better coverage with less maintenance overhead.

--- a/_rules/1622.md
+++ b/_rules/1622.md
@@ -4,7 +4,7 @@ rule_category: testability
 title: Test concrete implementations as part of a larger integration scope
 severity: 2
 ---
-Internal implementation details that are not individually reusable are best tested through the component that uses them, not in isolation. Testing every private helper class independently ties your test suite to the internal structure and makes refactoring harder.
+Internal implementation details that are not individually reusable are best tested through the component that uses them, not in isolation. Testing every internal type independently ties your test suite to the internal structure and makes refactoring harder.
 
 ```csharp
 // Avoid testing internal infrastructure directly


### PR DESCRIPTION
This PR adds guideline AV1622.

It was split out of #298 so the change can be reviewed independently.

Files:
- _rules/1622.md

Part of the replacement for #298.