### PR TITLE
Add AV2225: Use deconstruction to simplify variable assignments

### DIFF
--- a/_rules/2225.md
+++ b/_rules/2225.md
@@ -1,0 +1,31 @@
+---
+rule_id: 2225
+rule_category: dotnet-framework-usage
+title: Use deconstruction to simplify variable assignments
+severity: 3
+---
+C# supports deconstructing tuples, records, and any type that defines a `Deconstruct` method. Use this to avoid intermediate variables and make the intent of your code clearer.
+
+Instead of:
+
+	var point = GetOrigin();
+	var x = point.X;
+	var y = point.Y;
+
+write:
+
+	var (x, y) = GetOrigin();
+
+Similarly, deconstruct arrays and collections with pattern matching to avoid index-based access:
+
+	if (items is [var first, var second, ..])
+	{
+		// use first and second directly
+	}
+
+**Tip:** Deconstruction also works in `foreach` loops:
+
+	foreach (var (key, value) in dictionary)
+	{
+		Console.WriteLine($"{key}: {value}");
+	}

--- a/_rules/2225.md
+++ b/_rules/2225.md
@@ -8,24 +8,34 @@ C# supports deconstructing tuples, records, and any type that defines a `Deconst
 
 Instead of:
 
-	var point = GetOrigin();
-	var x = point.X;
-	var y = point.Y;
+```csharp
+public record Point(int X, int Y);
+
+Point point = GetOrigin();
+int x = point.X;
+int y = point.Y;
+```
 
 write:
 
-	var (x, y) = GetOrigin();
+```csharp
+(int x, int y) = GetOrigin();
+```
 
 Similarly, deconstruct arrays and collections with pattern matching to avoid index-based access:
 
-	if (items is [var first, var second, ..])
-	{
-		// use first and second directly
-	}
+```csharp
+if (items is [int first, int second, ..])
+{
+	// use first and second directly
+}
+```
 
 **Tip:** Deconstruction also works in `foreach` loops:
 
-	foreach (var (key, value) in dictionary)
-	{
-		Console.WriteLine($"{key}: {value}");
-	}
+```csharp
+foreach ((int key, int value) in dictionary)
+{
+	Console.WriteLine($"{key}: {value}");
+}
+```


### PR DESCRIPTION
This PR adds guideline AV2225.

It was split out of #298 so the change can be reviewed independently.

Files:
- _rules/2225.md

Part of the replacement for #298.