### PR TITLE
Add AV2308: Document what a member tries to do, not what it does or how it does it

### DIFF
--- a/_rules/2308.md
+++ b/_rules/2308.md
@@ -1,0 +1,23 @@
+---
+rule_id: 2308
+rule_category: commenting
+title: Document what a member tries to do, not what it does or how it does it
+severity: 2
+---
+The name of a type or member should describe its intent. Documentation should provide the *why* and the *what*, not describe the internals.
+
+Instead of:
+
+	/// <summary>
+	/// Iterates over the list and sets IsActive to false for each item.
+	/// </summary>
+	public void Deactivate(IEnumerable<Item> items)
+
+write:
+
+	/// <summary>
+	/// Marks all items as inactive so they are excluded from future processing.
+	/// </summary>
+	public void Deactivate(IEnumerable<Item> items)
+
+Documentation that simply restates the implementation gives no extra value and becomes a maintenance burden when the implementation changes.

--- a/_rules/2308.md
+++ b/_rules/2308.md
@@ -1,10 +1,10 @@
 ---
 rule_id: 2308
 rule_category: commenting
-title: Document what a member tries to do, not what it does or how it does it
+title: Document the purpose of a member, instead of describing its implementation
 severity: 2
 ---
-The name of a type or member should describe its intent. Documentation should provide the *why* and the *what*, not describe the internals.
+A member's name should describe its intent from a consumer perspective. Documentation should provide the *why* and the *what*, not describe the internals.
 
 Instead of:
 

--- a/_rules/2308.md
+++ b/_rules/2308.md
@@ -8,16 +8,20 @@ A member's name should describe its intent from a consumer perspective. Document
 
 Instead of:
 
-	/// <summary>
-	/// Iterates over the list and sets IsActive to false for each item.
-	/// </summary>
-	public void Deactivate(IEnumerable<Item> items)
+```csharp
+/// <summary>
+/// Iterates over the list and sets IsActive to false for each item.
+/// </summary>
+public void Deactivate(IEnumerable<Item> items)
+```
 
 write:
 
-	/// <summary>
-	/// Marks all items as inactive so they are excluded from future processing.
-	/// </summary>
-	public void Deactivate(IEnumerable<Item> items)
+```csharp
+/// <summary>
+/// Marks all items as inactive so they are excluded from future processing.
+/// </summary>
+public void Deactivate(IEnumerable<Item> items)
+```
 
 Documentation that simply restates the implementation gives no extra value and becomes a maintenance burden when the implementation changes.


### PR DESCRIPTION
This PR adds guideline AV2308.

It was split out of #298 so the change can be reviewed independently.

Files:
- _rules/2308.md

Part of the replacement for #298.