### PR TITLE
Remove AV1532: Avoid nested loops

### DIFF
--- a/_rules/1532.md
+++ b/_rules/1532.md
@@ -1,7 +1,0 @@
----
-rule_id: 1532
-rule_category: maintainability
-title: Avoid nested loops
-severity: 2
----
-A method that nests loops is more difficult to understand than one with only a single loop. In fact, in most cases nested loops can be replaced with a much simpler LINQ query that uses the `from` keyword twice or more to *join* the data.

--- a/_rules/1532.md
+++ b/_rules/1532.md
@@ -1,0 +1,7 @@
+---
+rule_id: 1532
+rule_category: maintainability
+title: Avoid nested loops
+severity: 2
+---
+A method that nests loops is more difficult to understand than one with only a single loop. 


### PR DESCRIPTION
This PR removes guideline AV1532.

It was split out of #298 so the change can be reviewed independently.

Files:
- _rules/1532.md

Part of the replacement for #298.