### PR TITLE
Remove AV1568: Don't use parameters as temporary variables

### DIFF
--- a/_rules/1568.md
+++ b/_rules/1568.md
@@ -1,7 +1,0 @@
----
-rule_id: 1568
-rule_category: maintainability
-title: Don't use parameters as temporary variables
-severity: 3
----
-Never use a parameter as a convenient variable for storing temporary state. Even though the type of your temporary variable may be the same, the name usually does not reflect the purpose of the temporary variable.


### PR DESCRIPTION
This PR removes guideline AV1568.

It was split out of #298 so the change can be reviewed independently.

Files:
- _rules/1568.md

Part of the replacement for #298.