### PR TITLE
Remove AV1738: Prefix an event handler with "On

### DIFF
--- a/_rules/1738.md
+++ b/_rules/1738.md
@@ -1,7 +1,0 @@
----
-rule_id: 1738
-rule_category: naming-conventions
-title: Prefix an event handler with "On"
-severity: 3
----
-It is good practice to prefix the method that handles an event with "On". For example, a method that handles its own `Closing` event should be named `OnClosing`. And a method that handles the `Click` event of its `okButton` field should be named `OkButtonOnClick`.


### PR DESCRIPTION
This PR removes guideline AV1738.

It was split out of #298 so the change can be reviewed independently.

Files:
- _rules/1738.md

Part of the replacement for #298.