### PR TITLE
Remove AV2201: Use C# type aliases instead of the types from the `System` namespace

### DIFF
--- a/_rules/2201.md
+++ b/_rules/2201.md
@@ -1,9 +1,0 @@
----
-rule_id: 2201
-rule_category: dotnet-framework-usage
-title: Use C# type aliases instead of the types from the `System` namespace
-severity: 1
----
-For instance, use `object` instead of `Object`, `string` instead of `String`, and `int` instead of `Int32`. These aliases have been introduced to make the primitive types first class citizens of the C# language, so use them accordingly. When referring to static members of those types, use `int.Parse()` instead of `Int32.Parse()`.
-
-**Exception:** For interop with other languages, it is custom to use the [CLS-compliant name](https://docs.microsoft.com/en-us/dotnet/standard/common-type-system) in type and member signatures, e.g. `HexToInt32Converter`, `GetUInt16`.


### PR DESCRIPTION
This PR removes guideline AV2201.

It was split out of #298 so the change can be reviewed independently.

Files:
- _rules/2201.md

Part of the replacement for #298.