### PR TITLE
Remove AV2307: Write MSDN-style documentation

### DIFF
--- a/_rules/2307.md
+++ b/_rules/2307.md
@@ -1,7 +1,0 @@
----
-rule_id: 2307
-rule_category: commenting
-title: Write MSDN-style documentation
-severity: 3
----
-Following the MSDN online help style and word choice helps developers find their way through your documentation more easily.


### PR DESCRIPTION
This PR removes guideline AV2307.

It was split out of #298 so the change can be reviewed independently.

Files:
- _rules/2307.md

Part of the replacement for #298.