### PR TITLE
Update AV1004: Use an interface rather than a base class to support multiple implementations

### DIFF
--- a/_rules/1004.md
+++ b/_rules/1004.md
@@ -4,4 +4,4 @@ rule_category: class-design
 title: Use an interface rather than a base class to support multiple implementations
 severity: 3
 ---
-If you want to expose an extension point from your class, expose it as an interface rather than as a base class. You don't want to force users of that extension point to derive their implementations from a base class that might have an undesired behavior. However, for their convenience you may implement a(n abstract) default implementation that can serve as a starting point.
+If you want to expose an extension point from your class, expose it as an interface rather than as a base class. You don't want to force users of that extension point to derive their implementations from a base class that might have an undesired behavior. However, for their convenience you may implement an abstract default implementation that can serve as a starting point.

--- a/_rules/1004.md
+++ b/_rules/1004.md
@@ -4,4 +4,4 @@ rule_category: class-design
 title: Use an interface rather than a base class to support multiple implementations
 severity: 3
 ---
-If you want to expose an extension point from your class, expose it as an interface rather than as a base class. You don't want to force users of that extension point to derive their implementations from a base class that might have an undesired behavior. However, for their convenience you may implement an abstract default implementation that can serve as a starting point.
+If you want to expose an extension point from your class, expose it as an interface rather than as a base class. You don't want to force users of that extension point to derive their implementations from a base class that might have an undesired behavior.


### PR DESCRIPTION
This PR updates guideline AV1004.

It was split out of #298 so the change can be reviewed independently.

Files:
- _rules/1004.md

Part of the replacement for #298.