### PR TITLE
Update AV1130: Return interfaces to unchangeable collections

### DIFF
--- a/_rules/1130.md
+++ b/_rules/1130.md
@@ -4,6 +4,8 @@ rule_category: member-design
 title: Return interfaces to unchangeable collections
 severity: 2
 ---
-You generally don't want callers to be able to change an internal collection, so don't return arrays, lists or other collection classes directly. Instead, return an `IEnumerable<T>`, `IAsyncEnumerable<T>`, `IQueryable<T>`, `IReadOnlyCollection<T>`, `IReadOnlyList<T>`, `IReadOnlySet<T>` or `IReadOnlyDictionary<TKey, TValue>`.
+You generally don't want callers to be able to change an internal collection, so don't return arrays, lists or other collection classes directly. Instead, return an `IEnumerable<T>`, `IAsyncEnumerable<T>`, `IReadOnlyCollection<T>`, `IReadOnlyList<T>`, `IReadOnlySet<T>` or `IReadOnlyDictionary<TKey, TValue>`.
+
+Be aware that `IEnumerable<T>` is often perceived as lazy-evaluated. If your collection is already materialized, consider returning `IReadOnlyCollection<T>` or even a plain array to make the intent clear.
 
 **Exception:** Immutable collections such as `ImmutableArray<T>`, `ImmutableList<T>` and `ImmutableDictionary<TKey, TValue>` prevent modifications from the outside and are thus allowed.

--- a/_rules/1130.md
+++ b/_rules/1130.md
@@ -4,8 +4,8 @@ rule_category: member-design
 title: Return interfaces to unchangeable collections
 severity: 2
 ---
-You generally don't want callers to be able to change an internal collection, so don't return arrays, lists or other collection classes directly. Instead, return an `IEnumerable<T>`, `IAsyncEnumerable<T>`, `IReadOnlyCollection<T>`, `IReadOnlyList<T>`, `IReadOnlySet<T>` or `IReadOnlyDictionary<TKey, TValue>`.
+You generally don't want callers to be able to change an internal collection, so don't return arrays, lists or other mutable collection classes directly. Instead, return an `IEnumerable<T>`, `IAsyncEnumerable<T>`, `IReadOnlyCollection<T>`, `IReadOnlyList<T>`, `IReadOnlySet<T>` or `IReadOnlyDictionary<TKey, TValue>`.
 
-Be aware that `IEnumerable<T>` is often perceived as lazy-evaluated. If your collection is already materialized, consider returning `IReadOnlyCollection<T>` or even a plain array to make the intent clear.
+Be aware that `IEnumerable<T>` is often perceived as lazy-evaluated. If your collection is already materialized, consider returning `IReadOnlyCollection<T>` or `IReadOnlyList<T>` to make the intent clear.
 
-**Exception:** Immutable collections such as `ImmutableArray<T>`, `ImmutableList<T>` and `ImmutableDictionary<TKey, TValue>` prevent modifications from the outside and are thus allowed.
+**Exception:** Immutable collections such as `ImmutableArray<T>`, `ImmutableList<T>` and `ImmutableDictionary<TKey, TValue>`, as well as `FrozenSet<T>` and `FrozenDictionary<TKey, TValue>` prevent modifications from the outside and are thus allowed.


### PR DESCRIPTION
This PR updates guideline AV1130.

It was split out of #298 so the change can be reviewed independently.

Files:
- _rules/1130.md

Part of the replacement for #298.