### PR TITLE
Update AV1137: Keep parameters as specific and narrow as possible

### DIFF
--- a/_rules/1137.md
+++ b/_rules/1137.md
@@ -1,7 +1,7 @@
 ---
 rule_id: 1137
 rule_category: member-design
-title: Define parameters as specific as possible
+title: Keep parameters as specific and narrow as possible
 severity: 2
 ---
 If your method or local function needs a specific piece of data, define parameters as specific as that and don't take a container object instead. For instance, consider a method that needs a connection string that is exposed through a central `IConfiguration` interface. Rather than taking a dependency on the entire configuration, just define a parameter for the connection string. This not only prevents unnecessary coupling, it also improves maintainability in the long run.

--- a/_rules/1137.md
+++ b/_rules/1137.md
@@ -1,7 +1,7 @@
 ---
 rule_id: 1137
 rule_category: member-design
-title: Keep parameters as specific and narrow as possible
+title: Define parameters as specific and narrow as possible
 severity: 2
 ---
 If your method or local function needs a specific piece of data, define parameters as specific as that and don't take a container object instead. For instance, consider a method that needs a connection string that is exposed through a central `IConfiguration` interface. Rather than taking a dependency on the entire configuration, just define a parameter for the connection string. This not only prevents unnecessary coupling, it also improves maintainability in the long run.


### PR DESCRIPTION
This PR updates guideline AV1137.

It was split out of #298 so the change can be reviewed independently.

Files:
- _rules/1137.md

Part of the replacement for #298.