### PR TITLE
AV1230: Consider providing property-changed events

### DIFF
--- a/_rules/1230.md
+++ b/_rules/1230.md
@@ -1,9 +1,0 @@
----
-rule_id: 1230
-rule_category: misc
-title: Consider providing property-changed events
-severity: 3
----
-Consider providing events that are raised when certain properties are changed. Such an event should be named `PropertyChanged`, where `Property` should be replaced with the name of the property with which this event is associated
-
-**Note:** If your class has many properties that require corresponding events, consider implementing the `INotifyPropertyChanged` interface instead. It is often used in the [Presentation Model](http://martinfowler.com/eaaDev/PresentationModel.html) and [Model-View-ViewModel](http://msdn.microsoft.com/en-us/magazine/dd419663.aspx) patterns.


### PR DESCRIPTION
This PR updates guideline AV1230.

It was split out of #298 so the change can be reviewed independently.

Files:
- _rules/1230.md

Part of the replacement for #298.