### PR TITLE
Update AV1500: Methods should not exceed 15 statements

### DIFF
--- a/_rules/1500.md
+++ b/_rules/1500.md
@@ -1,7 +1,7 @@
 ---
 rule_id: 1500
 rule_category: maintainability
-title: Methods should not exceed 7 statements
+title: Methods should not exceed 15 statements
 severity: 1
 ---
-A method that requires more than 7 statements is simply doing too much or has too many responsibilities. It also requires the human mind to analyze the exact statements to understand what the code is doing. Break it down into multiple small and focused methods with self-explaining names, but make sure the high-level algorithm is still clear.
+A method that requires more than 15 statements is simply doing too much or has too many responsibilities. It also requires the human mind to analyze the exact statements to understand what the code is doing. Break it down into multiple small and focused methods with self-explaining names, but make sure the high-level algorithm is still clear.

--- a/_rules/1500.md
+++ b/_rules/1500.md
@@ -5,3 +5,35 @@ title: Methods should not exceed 15 statements
 severity: 1
 ---
 A method that requires more than 15 statements is simply doing too much or has too many responsibilities. It also requires the human mind to analyze the exact statements to understand what the code is doing. Break it down into multiple small and focused methods with self-explaining names, but make sure the high-level algorithm is still clear.
+
+Also ensure that each method operates at a **single level of abstraction**. Mixing high-level functional calls (the "what") with low-level implementation details (the "how") in the same method makes it harder to understand the intent of the code.
+
+```csharp
+// Avoid: mixing abstraction levels in the same method
+void ProcessOrder(Order order)
+{
+    if (IsPremiumCustomer(order.CustomerId))  // functional; the "what"
+    {
+        ApplyDiscount(order);
+    }
+
+    if (Regex.IsMatch(order.Email.ToUpper().Trim(), @"^[^@]+@[^@]+\.[^@]+$"))  // technical; the "how"
+    {
+        SendConfirmation(order.Email);
+    }
+}
+
+// Better: extract the technical detail behind an abstraction
+void ProcessOrder(Order order)
+{
+    if (IsPremiumCustomer(order.CustomerId))
+    {
+        ApplyDiscount(order);
+    }
+
+    if (IsValidEmail(order.Email))
+    {
+        SendConfirmation(order.Email);
+    }
+}
+```


### PR DESCRIPTION
This PR updates guideline AV1500.

It was split out of #298 so the change can be reviewed independently.

Files:
- _rules/1500.md

Part of the replacement for #298.