### PR TITLE
Update AV1545: Don't use an `if`-`else` construct instead of a simple (conditional) assignment

### DIFF
--- a/_rules/1545.md
+++ b/_rules/1545.md
@@ -21,76 +21,18 @@ write:
 
 	bool isPositive = value > 0;
 
-Or instead of:
-
-	string classification;
-
-	if (value > 0)
-	{
-		classification = "positive";
-	}
-	else
-	{
-		classification = "negative";
-	}
-
-	return classification;
-
-write:
+Or use the ternary operator:
 
 	return value > 0 ? "positive" : "negative";
 
-Or instead of:
-
-	int result;
-
-	if (offset == null)
-	{
-		result = -1;
-	}
-	else
-	{
-		result = offset.Value;
-	}
-
-	return result;
-
-write:
+Or the null-coalescing operator:
 
 	return offset ?? -1;
 
-Or instead of:
+Or the null-coalescing assignment operator:
 
-	private DateTime? firstJobStartedAt;
+	firstJobStartedAt ??= DateTime.UtcNow;
 
-	public void RunJob()
-	{
-		if (firstJobStartedAt == null)
-		{
-			firstJobStartedAt = DateTime.UtcNow;
-		}
-	}
-
-write:
-
-	private DateTime? firstJobStartedAt;
-
-	public void RunJob()
-	{
-		firstJobStartedAt ??= DateTime.UtcNow;
-	}
-
-Or instead of:
-
-	if (employee.Manager != null)
-	{
-		return employee.Manager.Name;
-	}
-	else
-	{
-		return null;
-	}
-
-write:
+Or the conditional member access operator:
 
 	return employee.Manager?.Name;

--- a/_rules/1545.md
+++ b/_rules/1545.md
@@ -1,10 +1,10 @@
 ---
 rule_id: 1545
 rule_category: maintainability
-title: Don't use an `if`-`else` construct instead of a simple (conditional) assignment
+title: Use concise conditional expressions instead of `if`-`else` blocks
 severity: 2
 ---
-Express your intentions directly. For example, rather than:
+Write conditional expressions using modern, concise syntax. For example, rather than:
 
 	bool isPositive;
 


### PR DESCRIPTION
This PR updates guideline AV1545.

It was split out of #298 so the change can be reviewed independently.

Files:
- _rules/1545.md

Part of the replacement for #298.