### PR TITLE
Update AV1546: Prefer interpolated strings over concatenation or `string.Format`.

### DIFF
--- a/_rules/1546.md
+++ b/_rules/1546.md
@@ -4,7 +4,7 @@ rule_category: maintainability
 title: Prefer interpolated strings over concatenation or `string.Format`.
 severity: 1
 ---
-Since .NET 6, interpolated strings are optimized at compile-time, which inlines constants and reduces memory allocations due to boxing and string copying.
+Since .NET 6, interpolated strings are optimized at compile-time, which inlines constants and reduces memory allocations due to boxing and string copying. In .NET 8 and later, interpolated strings are further optimized using `DefaultInterpolatedStringHandler`, making them the fastest option in most scenarios.
 
 	// GOOD
 	string result = $"Welcome, {firstName} {lastName}!";
@@ -17,3 +17,5 @@ Since .NET 6, interpolated strings are optimized at compile-time, which inlines 
 
 	// BAD
 	string result = string.Concat("Welcome, ", firstName, " ", lastName, "!");
+
+For building strings in loops or with many parts, consider using `StringBuilder` or raw string literals (C# 11+) when appropriate.


### PR DESCRIPTION
This PR updates guideline AV1546.

It was split out of #298 so the change can be reviewed independently.

Files:
- _rules/1546.md

Part of the replacement for #298.