### PR TITLE
Update AV1553: Only use optional parameters to replace overloads

### DIFF
--- a/_rules/1553.md
+++ b/_rules/1553.md
@@ -4,7 +4,7 @@ rule_category: maintainability
 title: Only use optional parameters to replace overloads
 severity: 1
 ---
-The only valid reason for using C# 4.0's optional parameters is to replace the example from rule [{{ site.default_rule_prefix }}1551](#{{ site.default_rule_prefix }}1551) with a single method like:
+The only valid reason for using optional parameters is to replace the example from rule [{{ site.default_rule_prefix }}1551](#{{ site.default_rule_prefix }}1551) with a single method like:
 
 	public virtual int IndexOf(string phrase, int startIndex = 0, int count = -1)
 	{
@@ -14,10 +14,4 @@ The only valid reason for using C# 4.0's optional parameters is to replace the e
 
 Since strings, collections and tasks should never be `null` according to rule [{{ site.default_rule_prefix }}1135](/member-design-guidelines#{{ site.default_rule_prefix }}1135), if you have an optional parameter of these types with default value `null` then you must use overloaded methods instead.
 
-Strings, unlike other reference types, can have non-null default values. So an optional string parameter may be used to replace overloads with the condition of having a non-null default value.
-
-Regardless of optional parameters' types, following caveats always apply:
-
-1) The default values of the optional parameters are stored at the caller side. As such, changing the default argument without recompiling the calling code will not apply the new default value. Unless your method is private or internal, this aspect should be carefully considered before choosing optional parameters over method overloads.
-
-2) If optional parameters cause the method to follow and/or exit from alternative paths, overloaded methods are probably a better fit for your case.
+Be aware that the default values of optional parameters are stored at the caller side. Changing the default argument without recompiling the calling code will not apply the new default value.


### PR DESCRIPTION
This PR updates guideline AV1553.

It was split out of #298 so the change can be reviewed independently.

Files:
- _rules/1553.md

Part of the replacement for #298.