### PR TITLE
Update AV1554: Do not use optional parameters in interface methods or their concrete implementations

### DIFF
--- a/_rules/1554.md
+++ b/_rules/1554.md
@@ -1,11 +1,11 @@
 ---
 rule_id: 1554
 rule_category: maintainability
-title: Do not use optional parameters in interface methods or their concrete implementations
+title: Do not use optional parameters with defaults in interface methods or their concrete implementations
 severity: 1
 ---
-When an interface method defines an optional parameter, its default value is discarded during overload resolution unless you call the concrete class through the interface reference.
+When an interface method defines an optional parameter with a default value, its default value is discarded during overload resolution unless you call the concrete class through the interface reference.
 
 When a concrete implementation of an interface method sets a default argument for a parameter, the default value is discarded during overload resolution if you call the concrete class through the interface reference.
 
-See the series on optional argument corner cases by Eric Lippert (part [one](https://docs.microsoft.com/en-us/archive/blogs/ericlippert/optional-argument-corner-cases-part-one), [two](https://docs.microsoft.com/en-us/archive/blogs/ericlippert/optional-argument-corner-cases-part-two), [three](https://docs.microsoft.com/en-us/archive/blogs/ericlippert/optional-argument-corner-cases-part-three), [four](https://docs.microsoft.com/en-us/archive/blogs/ericlippert/optional-argument-corner-cases-part-four)) for more details.
+See the series on optional argument corner cases by Eric Lippert (part [one](https://learn.microsoft.com/en-us/archive/blogs/ericlippert/optional-argument-corner-cases-part-one), [two](https://learn.microsoft.com/en-us/archive/blogs/ericlippert/optional-argument-corner-cases-part-two), [three](https://learn.microsoft.com/en-us/archive/blogs/ericlippert/optional-argument-corner-cases-part-three), [four](https://learn.microsoft.com/en-us/archive/blogs/ericlippert/optional-argument-corner-cases-part-four)) for more details.


### PR DESCRIPTION
This PR updates guideline AV1554.

It was split out of #298 so the change can be reviewed independently.

Files:
- _rules/1554.md

Part of the replacement for #298.