### PR TITLE
Update AV1701: Use US English

### DIFF
--- a/_rules/1701.md
+++ b/_rules/1701.md
@@ -8,4 +8,3 @@ All identifiers (such as types, type members, parameters and variables) should b
 
 - Choose easily readable, preferably grammatically correct names. For example, `HorizontalAlignment` is more readable than `AlignmentHorizontal`.
 - Favor readability over brevity. The property name `CanScrollHorizontally` is better than `ScrollableX` (an obscure reference to the X-axis).
-- Avoid using names that conflict with keywords of widely used programming languages.


### PR DESCRIPTION
This PR updates guideline AV1701.

It was split out of #298 so the change can be reviewed independently.

Files:
- _rules/1701.md

Part of the replacement for #298.