### PR TITLE
Update AV1706: Don't use abbreviations

### DIFF
--- a/_rules/1706.md
+++ b/_rules/1706.md
@@ -6,4 +6,4 @@ severity: 2
 ---
 For example, use `ButtonOnClick` rather than `BtnOnClick`. Avoid single character variable names, such as `i` or `q`. Use `index` or `query` instead.
 
-**Exceptions:** Use well-known acronyms and abbreviations that are widely accepted or well-known in your work domain. For instance, use acronym `UI` instead of `UserInterface` and abbreviation `Id` instead of `Identity`.
+**Exceptions:** Use well-known acronyms and abbreviations that are widely accepted or well-known in your work domain. For instance, use acronym `UI` instead of `UserInterface` and abbreviation `Id` instead of `Identity`. For abbreviations of two letters, use all capitals (e.g. `IO`). For abbreviations longer than two letters, only capitalize the first letter (e.g. `Http`, `Xml`, `Json`).

--- a/_rules/1706.md
+++ b/_rules/1706.md
@@ -4,6 +4,6 @@ rule_category: naming-conventions
 title: Don't use abbreviations
 severity: 2
 ---
-For example, use `ButtonOnClick` rather than `BtnOnClick`. Avoid single character variable names, such as `i` or `q`. Use `index` or `query` instead.
+For example, use `ChangePassword` rather than `ChangePwd`. Avoid single-character variable names, such as `i` or `q`. Use `index` or `query` instead.
 
 **Exceptions:** Use well-known acronyms and abbreviations that are widely accepted or well-known in your work domain. For instance, use acronym `UI` instead of `UserInterface` and abbreviation `Id` instead of `Identity`. For abbreviations of two letters, use all capitals (e.g. `IO`). For abbreviations longer than two letters, only capitalize the first letter (e.g. `Http`, `Xml`, `Json`).


### PR DESCRIPTION
This PR updates guideline AV1706.

It was split out of #298 so the change can be reviewed independently.

Files:
- _rules/1706.md

Part of the replacement for #298.