### PR TITLE
Update AV1735: Use a verb or verb phrase to name an event

### DIFF
--- a/_rules/1735.md
+++ b/_rules/1735.md
@@ -7,3 +7,11 @@ severity: 2
 Name events with a verb or a verb phrase. For example: `Click`, `Deleted`, `Closing`, `Minimizing`, and `Arriving`. For example, the declaration of the `Search` event may look like this:
 
 	public event EventHandler<SearchArgs> Search;
+
+Use `-ing` and `-ed` to express pre-events and post-events. For example, a close event that is raised before a window is closed would be called `Closing`, and one that is raised after the window is closed would be called `Closed`. Don't use `Before` or `After` prefixes or suffixes to indicate pre and post events.
+
+Suppose you want to define events related to the deletion of an object. Avoid defining the `Deleting` and `Deleted` events as `BeginDelete` and `EndDelete`. Define those events as follows:
+
+- `Deleting`: Occurs just before the object is getting deleted.
+- `Delete`: Occurs when the object needs to be deleted by the event handler.
+- `Deleted`: Occurs when the object is already deleted.


### PR DESCRIPTION
This PR updates guideline AV1735.

It was split out of #298 so the change can be reviewed independently.

Files:
- _rules/1735.md

Part of the replacement for #298.