### PR TITLE
Update AV1755: Only use `Async` or `TaskAsync` as a suffix when a method has both synchronous and asynchronous versions

### DIFF
--- a/_rules/1755.md
+++ b/_rules/1755.md
@@ -4,4 +4,4 @@ rule_category: naming-conventions
 title: Only use `Async` or `TaskAsync` as a suffix when a method has both synchronous and asynchronous versions
 severity: 2
 ---
-Only postfix a method or local function that returns `Task` or `Task<TResult>` with `Async` if there is also a synchronous version of that method. If the only version is asynchronous, the `Async` suffix adds unnecessary noise. If both synchronous and asynchronous versions exist, use `Async` as the postfix. If a method named `Async` already exists, use `TaskAsync` instead.
+Only suffix a method or local function that returns `Task` or `Task<TResult>` with `Async` if there is also a synchronous version of that method. If the only version is asynchronous, the `Async` suffix adds unnecessary noise. If both synchronous and asynchronous versions exist, use `Async` as the postfix. If a method named `Async` already exists, use `TaskAsync` instead.

--- a/_rules/1755.md
+++ b/_rules/1755.md
@@ -1,7 +1,7 @@
 ---
 rule_id: 1755
 rule_category: naming-conventions
-title: Postfix asynchronous methods with `Async` or `TaskAsync`
+title: Only use `Async` or `TaskAsync` as a suffix when a method has both synchronous and asynchronous versions
 severity: 2
 ---
-The general convention for methods and local functions that return `Task` or `Task<TResult>` is to postfix them with `Async`. But if such a method already exists, use `TaskAsync` instead.
+Only postfix a method or local function that returns `Task` or `Task<TResult>` with `Async` if there is also a synchronous version of that method. If the only version is asynchronous, the `Async` suffix adds unnecessary noise. If both synchronous and asynchronous versions exist, use `Async` as the postfix. If a method named `Async` already exists, use `TaskAsync` instead.

--- a/_rules/1755.md
+++ b/_rules/1755.md
@@ -4,4 +4,4 @@ rule_category: naming-conventions
 title: Only use `Async` or `TaskAsync` as a suffix when a method has both synchronous and asynchronous versions
 severity: 2
 ---
-Only suffix a method or local function that returns `Task` or `Task<TResult>` with `Async` if there is also a synchronous version of that method. If the only version is asynchronous, the `Async` suffix adds unnecessary noise. If both synchronous and asynchronous versions exist, use `Async` as the postfix. If a method named `Async` already exists, use `TaskAsync` instead.
+Only suffix a method or local function that returns `Task` or `Task<TResult>` with `Async` if there is also a synchronous variant of that method. If no synchronous variant exists, the `Async` suffix adds unnecessary noise. If both synchronous and asynchronous variants exist, use `Async` as the suffix. If a method suffixed with `Async` already exists, use `TaskAsync` instead.


### PR DESCRIPTION
This PR updates guideline AV1755.

It was split out of #298 so the change can be reviewed independently.

Files:
- _rules/1755.md

Part of the replacement for #298.