### PR TITLE
Update AV1820: Only use `async` for I/O-bound or long-running activities

### DIFF
--- a/_rules/1580.md
+++ b/_rules/1580.md
@@ -4,12 +4,10 @@ rule_category: maintainability
 title: Write code that is easy to debug
 severity: 2
 ---
-Because debugger breakpoints cannot be set inside expressions, avoid overuse of nested method calls. For example, in some IDEs, a line like:
+Because debugger breakpoints cannot be set inside expressions, avoid overuse of nested method calls. For example, a line like:
 
 	string result = ConvertToXml(ApplyTransforms(ExecuteQuery(GetConfigurationSettings(source))));
 
 requires extra steps to inspect intermediate method return values. On the other hard, were this expression broken into intermediate variables, setting a breakpoint on one of them would be sufficient.
 
-**Note:** This does not apply to chaining method calls, which is a common pattern in fluent APIs.
-
-**Tip:** [JetBrains Rider](https://www.jetbrains.com/rider/) has a very advanced debugger that allows you to choose into which part of a nested or chained call you want to step. It also displays all intermediate parameter and return values.
+**Note** This does not apply to chaining method calls, which is a common pattern in fluent APIs.

--- a/_rules/1580.md
+++ b/_rules/1580.md
@@ -4,10 +4,12 @@ rule_category: maintainability
 title: Write code that is easy to debug
 severity: 2
 ---
-Because debugger breakpoints cannot be set inside expressions, avoid overuse of nested method calls. For example, a line like:
+Because debugger breakpoints cannot be set inside expressions, avoid overuse of nested method calls. For example, in some IDEs, a line like:
 
 	string result = ConvertToXml(ApplyTransforms(ExecuteQuery(GetConfigurationSettings(source))));
 
 requires extra steps to inspect intermediate method return values. On the other hard, were this expression broken into intermediate variables, setting a breakpoint on one of them would be sufficient.
 
-**Note** This does not apply to chaining method calls, which is a common pattern in fluent APIs.
+**Note:** This does not apply to chaining method calls, which is a common pattern in fluent APIs.
+
+**Tip:** [JetBrains Rider](https://www.jetbrains.com/rider/) has a very advanced debugger that allows you to choose into which part of a nested or chained call you want to step. It also displays all intermediate parameter and return values.

--- a/_rules/1820.md
+++ b/_rules/1820.md
@@ -1,7 +1,9 @@
 ---
 rule_id: 1820
 rule_category: performance
-title: Only use `async` for low-intensive long-running activities
+title: Only use `async`/`await` for I/O-bound or long-running activities
 severity: 1
 ---
-The usage of `async` won't automagically run something on a worker thread like `Task.Run` does. It just adds the necessary logic to allow releasing the current thread, and marshal the result back on that same thread if a long-running asynchronous operation has completed. In other words, use `async` only for I/O bound operations.
+The usage of `async` won't automagically run something on a worker thread like `Task.Run` does. It just adds the necessary logic to allow releasing the current thread, and marshal the result back on that same thread if a long-running asynchronous operation has completed. In other words, use `async` only for I/O-bound operations.
+
+**Exception:** Tasks returned from `Task.Run` (which starts a background operation in parallel) can eventually be awaited to obtain their results, or passed to a method like `Task.WhenAll` that is awaited.

--- a/_rules/1820.md
+++ b/_rules/1820.md
@@ -4,6 +4,6 @@ rule_category: performance
 title: Only use `async`/`await` for I/O-bound or long-running activities
 severity: 1
 ---
-The usage of `async` won't automagically run something on a worker thread like `Task.Run` does. It just adds the necessary logic to allow releasing the current thread, and marshal the result back on that same thread if a long-running asynchronous operation has completed. In other words, use `async` only for I/O-bound operations.
+The use of `async`/`await` won't automagically run something on a worker thread as `Task.Run` does. It just suspends execution at the await point and resumes execution after the task has completed. In other words, use `async`/`await` only for I/O-bound operations.
 
 **Exception:** Tasks returned from `Task.Run` (which starts a background operation in parallel) can eventually be awaited to obtain their results, or passed to a method like `Task.WhenAll` that is awaited.


### PR DESCRIPTION
This PR updates guideline AV1820.

It was split out of #298 so the change can be reviewed independently.

Files:
- _rules/1820.md

Part of the replacement for #298.