### PR TITLE
Update AV2202: Prefer language syntax over explicit calls to underlying implementations

### DIFF
--- a/_rules/2202.md
+++ b/_rules/2202.md
@@ -24,7 +24,15 @@ rather than:
 
 Prefer:
 
-	if (startDate != null) ...
+	if (startDate is null) ...
+
+rather than:
+
+	if (startDate == null) ...
+
+Prefer:
+
+	if (startDate is not null) ...
 
 rather than:
 
@@ -40,11 +48,16 @@ rather than:
 
 Prefer:
 
-	(DateTime startTime, TimeSpan duration) tuple1 = GetTimeRange();
-	(DateTime startTime, TimeSpan duration) tuple2 = GetTimeRange();
-
-	if (tuple1 == tuple2) ...
+	List<string> items = [];
 
 rather than:
 
-	if (tuple1.startTime == tuple2.startTime && tuple1.duration == tuple2.duration) ...
+	List<string> items = new List<string>();
+
+Prefer (C# 14):
+
+	list ??= [];
+
+rather than:
+
+	if (list == null) list = [];

--- a/_rules/2202.md
+++ b/_rules/2202.md
@@ -1,10 +1,10 @@
 ---
 rule_id: 2202
 rule_category: dotnet-framework-usage
-title: Prefer language syntax over explicit calls to underlying implementations
+title: Prefer idiomatic C# over .NET Framework APIs
 severity: 1
 ---
-Language syntax makes code more concise. The abstractions make later refactorings easier (and sometimes allow for extra optimizations).
+C#'s language syntax makes code more concise. The abstractions make later refactorings easier (and sometimes allow for extra optimizations).
 
 Prefer:
 


### PR DESCRIPTION
This PR updates guideline AV2202.

It was split out of #298 so the change can be reviewed independently.

Files:
- _rules/2202.md

Part of the replacement for #298.