### PR TITLE
Update AV2305: Document all `public`, `protected` and `internal` types and members

### DIFF
--- a/_rules/2305.md
+++ b/_rules/2305.md
@@ -5,3 +5,7 @@ title: Document all `public`, `protected` and `internal` types and members
 severity: 2
 ---
 Documenting your code allows Visual Studio, [Visual Studio Code](https://code.visualstudio.com/) or [Jetbrains Rider](https://www.jetbrains.com/rider/) to pop-up the documentation when your class is used somewhere else. Furthermore, by properly documenting your classes, tools can generate professionally looking class documentation.
+
+**Note:** For internal types and members that are only used within a single assembly, XML documentation is optional. However, a brief summary comment can still be helpful for future maintainers.
+
+**Note:** You don't need to use `/// <inheritdoc/>` on overriding or implementing members. Visual Studio and Rider will automatically inherit documentation from the base type or interface.

--- a/_rules/2305.md
+++ b/_rules/2305.md
@@ -4,8 +4,10 @@ rule_category: commenting
 title: Document all `public`, `protected` and `internal` types and members
 severity: 2
 ---
-Documenting your code allows Visual Studio, [Visual Studio Code](https://code.visualstudio.com/) or [Jetbrains Rider](https://www.jetbrains.com/rider/) to pop-up the documentation when your class is used somewhere else. Furthermore, by properly documenting your classes, tools can generate professionally looking class documentation.
+Good functional documentation allows Visual Studio, [Visual Studio Code](https://code.visualstudio.com/) or [Jetbrains Rider](https://www.jetbrains.com/rider/) to display the documentation when your class is used somewhere else. Furthermore, by properly documenting your classes, tools can generate professionally looking class documentation.
 
-**Note:** For internal types and members that are only used within a single assembly, XML documentation is optional. However, a brief summary comment can still be helpful for future maintainers.
+See also [{{ site.default_rule_prefix }}2306](/documentation-guidelines#{{ site.default_rule_prefix }}2306) 
+
+**Exception:** Sometimes the purpose is so obvious that the documentation would become repetitive. Don't do that.
 
 **Note:** You don't need to use `/// <inheritdoc/>` on overriding or implementing members. Visual Studio and Rider will automatically inherit documentation from the base type or interface.


### PR DESCRIPTION
This PR updates guideline AV2305.

It was split out of #298 so the change can be reviewed independently.

Files:
- _rules/2305.md

Part of the replacement for #298.