### PR TITLE
Add page: Testability Guidelines

### DIFF
--- a/_pages/1600_TestabilityGuidelines.md
+++ b/_pages/1600_TestabilityGuidelines.md
@@ -1,0 +1,10 @@
+---
+title: Testability Guidelines
+permalink: /testability-guidelines/
+classes: wide
+search: true
+sidebar:
+  nav: "sidebar"
+rule_category: testability
+layout: rule-category
+---


### PR DESCRIPTION
This PR adds page _pages/1600_TestabilityGuidelines.md.

It was split out of #298 so the change can be reviewed independently.

Files:
- _pages/1600_TestabilityGuidelines.md

Part of the replacement for #298.