### PR TITLE
Clarify suffix usage for Async methods

### DIFF
--- a/_rules/1755.md
+++ b/_rules/1755.md
@@ -1,7 +1,7 @@
 ---
 rule_id: 1755
 rule_category: naming-conventions
-title: Only use `Async` or `TaskAsync` as a suffix when a method has both synchronous and asynchronous versions
+title: Only suffix methods with `Async` or `TaskAsync` when both synchronous and asynchronous variants exist
 severity: 2
 ---
 Only suffix a method or local function that returns `Task` or `Task<TResult>` with `Async` if there is also a synchronous variant of that method. If no synchronous variant exists, the `Async` suffix adds unnecessary noise. If both synchronous and asynchronous variants exist, use `Async` as the suffix. If a method suffixed with `Async` already exists, use `TaskAsync` instead.


### PR DESCRIPTION
Follow-up for #374, to align with the replacement of "version" with "variant".