### PR TITLE
Update AV1011: Add LSP example with polymorphism

### DIFF
--- a/_rules/1011.md
+++ b/_rules/1011.md
@@ -6,4 +6,56 @@ severity: 2
 ---
 In other words, you should be able to pass an instance of a derived class wherever its base class is expected, without the callee knowing the derived class. A very notorious example of a violation of this rule is throwing a `NotImplementedException` when overriding methods from a base class. A less subtle example is not honoring the behavior expected by the base class.
 
-**Note:** This rule is also known as the Liskov Substitution Principle, one of the [S.O.L.I.D.](https://en.wikipedia.org/wiki/SOLID) principles.
+```csharp
+// Wrong
+public abstract class Shape { }
+
+public class Circle : Shape
+{
+    public double Radius { get; set; }
+}
+
+public class Square : Shape
+{
+    public double Side { get; set; }
+}
+
+public class ShapeProcessor
+{
+    public double CalculateArea(Shape shape)
+    {
+        if (shape is Circle circle)
+            return Math.PI * circle.Radius * circle.Radius;
+
+        if (shape is Square square)
+            return square.Side * square.Side;
+
+        throw new NotSupportedException();
+    }
+}
+```
+
+Instead, use polymorphism:
+
+```csharp
+public abstract class Shape
+{
+    public abstract double CalculateArea();
+}
+
+public class Circle : Shape
+{
+    public double Radius { get; set; }
+
+    public override double CalculateArea() => Math.PI * Radius * Radius;
+}
+
+public class Square : Shape
+{
+    public double Side { get; set; }
+
+    public override double CalculateArea() => Side * Side;
+}
+```
+
+**Note:** This rule is also known as the Liskov Substitution Principle, one of the [S.O.L.I.D.](http://www.lostechies.com/blogs/chad_myers/archive/2008/03/07/pablo-s-topic-of-the-month-march-solid-principles.aspx) principles.


### PR DESCRIPTION
Moves the Shape/Circle/Square example from AV1013 to AV1011, where it better illustrates the Liskov Substitution Principle. Also converts indented code blocks to fenced \\\csharp code blocks.