### PR TITLE
Exclude dependabot PRs from release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot


### PR DESCRIPTION
Adds `.github/release.yml` to configure GitHub's auto-generated release notes to exclude pull requests authored by `dependabot`. This keeps the changelog focused on meaningful changes.