### PR TITLE
Update release notes config to group by label and exclude dependabot

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,3 +2,18 @@ changelog:
   exclude:
     authors:
       - dependabot
+    labels:
+      - dependencies
+  categories:
+    - title: New
+      labels:
+        - new
+    - title: Deprecated
+      labels:
+        - deprecated
+    - title: Refined
+      labels:
+        - refined
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
## Summary

Updates \.github/release.yml\ to improve auto-generated release notes.

### Changes
- **Group by label**: Changelog entries are now categorised into **New**, **Deprecated**, **Refined**, and **Other Changes**
- **Exclude dependabot**: Filters out both dependabot-authored PRs and PRs with the \dependencies\ label