### PR TITLE
Update cheatsheet and build branding

### DIFF
--- a/Build/default.ps1
+++ b/Build/default.ps1
@@ -5,6 +5,26 @@ properties {
 	$defaultRulePrefix = "AV"
 }
 
+function SetVersionFromGitMetadata {
+	param([string]$baseDirectory)
+
+	$description = (git -C $baseDirectory describe --tags --long --always)
+
+	if ($description -match '^(?<tag>\d+\.\d+\.\d+)-(?<count>\d+)-g(?<sha>[0-9a-f]+)$') {
+		if ($Matches['count'] -eq '0') {
+			$script:SemVer = $Matches['tag']
+		}
+		else {
+			$script:SemVer = "$($Matches['tag'])-ci.$($Matches['count'])+g$($Matches['sha'])"
+		}
+	}
+	else {
+		$script:SemVer = $description
+	}
+
+	$script:CommitDate = ([datetime](git -C $baseDirectory log -1 --format=%cI HEAD)).ToString("MMMM d, yyyy")
+}
+
 task default -depends Clean, ExtractVersionsFromGit, Compile, CompileCheatsheet, BuildHtml
 
 task Clean {
@@ -15,7 +35,12 @@ task Clean {
 
 task ExtractVersionsFromGit {
 
-        $json = . "$LibDir\GitVersion.exe"
+        if (Test-Path "$BaseDirectory\.git" -PathType Leaf) {
+            SetVersionFromGitMetadata $BaseDirectory
+            return
+        }
+
+        $json = . "$LibDir\GitVersion.exe" 2>&1
 
         if ($LASTEXITCODE -eq 0) {
             $version = (ConvertFrom-Json ($json -join "`n"));
@@ -24,7 +49,7 @@ task ExtractVersionsFromGit {
             $script:CommitDate = ([datetime]$version.CommitDate).ToString("MMMM d, yyyy");
         }
         else {
-            Write-Output $json -join "`n";
+            SetVersionFromGitMetadata $BaseDirectory
         }
 }
 
@@ -105,7 +130,12 @@ task Compile {
 						$ruleIdPrefix = $Matches[2].Trim()
 					}
 
-					$content += "<div id=`"${ruleIdPrefix}${ruleId}`"></div>### $ruleTitle (${ruleIdPrefix}${ruleId}) <img src=`"assets/images/$ruleSeverity.png`" />`n"
+					$severityIcon = ""
+					if (-not [string]::IsNullOrWhiteSpace($ruleSeverity)) {
+						$severityIcon = " <img src=`"assets/images/$ruleSeverity.png`" />"
+					}
+
+					$content += "<div id=`"${ruleIdPrefix}${ruleId}`"></div>### $ruleTitle (${ruleIdPrefix}${ruleId})$severityIcon`n"
 
 					# Add rule content without Frontmatter
 					$content += ($rule -replace '---\r?\n(.|\r?\n)+?---\r?\n', "")

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Coding Guidelines for C# (up to v10)
+Coding Guidelines for C# (up to v14)
 ================
 
 See the landing page at https://www.csharpcodingguidelines.com

--- a/_pages/Cheatsheet.md
+++ b/_pages/Cheatsheet.md
@@ -5,11 +5,11 @@ NOTE: Requires Markdown Extra. See http://michelf.ca/projects/php-markdown/extra
 
 <table width="100%">
 <tr>
-<td class="title" width="70%">Coding Guidelines for C# v10 Cheat Sheet</td>
+<td class="title" width="70%">Coding Guidelines for C# v14 Cheat Sheet</td>
 <td rowspan="2" style="text-align:right">![logo](assets/images/logo.svg)</td>
 </tr>
 <tr>
-<td><div class="subTitle">Design & Maintainability</div> (level 1 and 2 only)</td>
+<td><div class="subTitle">General, Design & Maintainability</div></td>
 </tr>
 </table>
 
@@ -17,97 +17,90 @@ NOTE: Requires Markdown Extra. See http://michelf.ca/projects/php-markdown/extra
 <tr>
 <td class="column" markdown="1">
 <div markdown="1" class="sidebar">
-**Basic Principles**
+**Core principles**
 
-* The Principle of Least Surprise
+* Understand the boundaries of your codebase
+* Prefer composition over inheritance
+* Apply the Principle of Least Surprise
 * Keep It Simple Stupid
 * You Ain't Gonna Need It
 * Don't Repeat Yourself
-* OOP: Encapsulation, abstraction, inheritance, polymorphism
+* Treat AI-generated code as your own
 </div>
 
+**General**
+
+* Understand the boundaries of your codebase ({{ site.default_rule_prefix }}0100)
+* Prefer composition over inheritance ({{ site.default_rule_prefix }}0110)
+* Apply the Principle of Least Surprise ({{ site.default_rule_prefix }}0112)
+* Keep It Simple Stupid (KISS) ({{ site.default_rule_prefix }}0115)
+* You Ain't Gonna Need It (YAGNI) ({{ site.default_rule_prefix }}0120)
+* Don't Repeat Yourself (DRY), but only within boundaries ({{ site.default_rule_prefix }}0125)
+* Apply the four pillars of object-oriented programming ({{ site.default_rule_prefix }}0130)
+* Treat AI-generated code as your own ({{ site.default_rule_prefix }}0135)
+
+<br/>
 **Class Design**
 
 * A class or interface should have a single purpose ({{ site.default_rule_prefix }}1000)
-* An interface should be small and focused ({{ site.default_rule_prefix }}1003)
+* Only include constructor parameters that most or all members need ({{ site.default_rule_prefix }}1002)
+* Use an interface rather than a base class to support multiple implementations ({{ site.default_rule_prefix }}1004)
 * Use an interface to decouple classes from each other ({{ site.default_rule_prefix }}1005)
-* Don't suppress compiler warnings using the `new` keyword ({{ site.default_rule_prefix }}1010)
-* It should be possible to treat a derived object as if it were a base class object ({{ site.default_rule_prefix }}1011)
-* Don't refer to derived classes from the base class ({{ site.default_rule_prefix }}1013)
-* Avoid exposing the other objects an object depends on ({{ site.default_rule_prefix }}1014)
+* It should be possible to treat a derived type as if it were a base type ({{ site.default_rule_prefix }}1011)
 * Avoid bidirectional dependencies ({{ site.default_rule_prefix }}1020)
-* Classes should have state and behavior ({{ site.default_rule_prefix }}1025)
 * Classes should protect the consistency of their internal state ({{ site.default_rule_prefix }}1026)
-
-<br/>
+* Know when to use a record and when to use a class ({{ site.default_rule_prefix }}1030)
+* Consider a named delegate instead of an interface with a single method ({{ site.default_rule_prefix }}1032)
+</td>
+<td class="column">
 **Member Design**
 
 * Allow properties to be set in any order ({{ site.default_rule_prefix }}1100)
 * Don't use mutually exclusive properties ({{ site.default_rule_prefix }}1110)
 * A property, method or local function should do only one thing ({{ site.default_rule_prefix }}1115)
-* Don't expose stateful objects through static members ({{ site.default_rule_prefix }}1125)
-* Return an `IEnumerable<T>` or `ICollection<T>` instead of a concrete collection class ({{ site.default_rule_prefix }}1130)
-* Properties, arguments and return values representing strings, collections or tasks should never be `null` ({{ site.default_rule_prefix }}1135)
-* Define parameters as specific as possible ({{ site.default_rule_prefix }}1137)
-</td>
-<td class="column">
+* Don't hide dependencies behind static members ({{ site.default_rule_prefix }}1125)
+* Return interfaces to unchangeable collections ({{ site.default_rule_prefix }}1130)
+* Define parameters as specific and narrow as possible ({{ site.default_rule_prefix }}1137)
+* Consider creating domain-specific types rather than using primitives ({{ site.default_rule_prefix }}1140)
+* Use extension members to add behavior without modifying the original type ({{ site.default_rule_prefix }}1145)
+
+<br/>
 **Miscellaneous Design**
 
 * Throw exceptions rather than returning some kind of status value ({{ site.default_rule_prefix }}1200)
-* Provide a rich and meaningful exception message text ({{ site.default_rule_prefix }}1202)
+* Throw the most specific exception that is appropriate ({{ site.default_rule_prefix }}1205)
 * Don't swallow errors by catching generic exceptions ({{ site.default_rule_prefix }}1210)
 * Properly handle exceptions in asynchronous code ({{ site.default_rule_prefix }}1215)
-* Always check an event handler delegate for `null` ({{ site.default_rule_prefix }}1220)
 * Use a protected virtual method to raise each event ({{ site.default_rule_prefix }}1225)
-* Don't pass `null` as the `sender` argument when raising an event ({{ site.default_rule_prefix }}1235)
-* Use generic constraints if applicable ({{ site.default_rule_prefix }}1240)
-* Evaluate the result of a LINQ expression before returning it ({{ site.default_rule_prefix }}1250)
+* Materialize the result of a LINQ expression before returning it ({{ site.default_rule_prefix }}1250)
 * Do not use `this` and `base` prefixes unless it is required ({{ site.default_rule_prefix }}1251)
-
-<br/>
-**Maintainability**
-
-* Methods should not exceed 7 statements ({{ site.default_rule_prefix }}1500)
-* Make all members `private` and types `internal sealed` by default ({{ site.default_rule_prefix }}1501)
-* Avoid conditions with double negatives ({{ site.default_rule_prefix }}1502)
-* Don't use "magic" numbers ({{ site.default_rule_prefix }}1515)
-* Only use `var` when the type is very obvious ({{ site.default_rule_prefix }}1520)
-* Declare and initialize variables as late as possible ({{ site.default_rule_prefix }}1521)
-* Assign each variable in a separate statement ({{ site.default_rule_prefix }}1522)
-* Favor object and collection initializers over separate statements ({{ site.default_rule_prefix }}1523)
-* Don't make explicit comparisons to `true` or `false` ({{ site.default_rule_prefix }}1525)
-* Don't change a loop variable inside a `for` loop ({{ site.default_rule_prefix }}1530)
-* Avoid nested loops ({{ site.default_rule_prefix }}1532)
 </td>
 <td class="column">
+**Maintainability**
+
+* Methods should not exceed 15 statements ({{ site.default_rule_prefix }}1500)
+* Make all members `private` and types `internal sealed` by default ({{ site.default_rule_prefix }}1501)
+* Don't use "magic" numbers ({{ site.default_rule_prefix }}1515)
+* Only use `var` when the type is evident ({{ site.default_rule_prefix }}1520)
+* Favor object and collection initializers over separate statements ({{ site.default_rule_prefix }}1523)
 * Always add a block after the keywords `if`, `else`, `do`, `while`, `for`, `foreach` and `case` ({{ site.default_rule_prefix }}1535)
-* Always add a `default` block after the last `case` in a `switch` statement ({{ site.default_rule_prefix }}1536)
-* Finish every `if`-`else`-`if` statement with an `else` clause ({{ site.default_rule_prefix }}1537)
-* Be reluctant with multiple `return` statements ({{ site.default_rule_prefix }}1540)
-* Don't use an `if`-`else` construct instead of a simple (conditional) assignment ({{ site.default_rule_prefix }}1545)
-* Encapsulate complex expressions in a property, method or local function ({{ site.default_rule_prefix }}1547)
-* Call the more overloaded method from other overloads ({{ site.default_rule_prefix }}1551)
-* Only use optional parameters to replace overloads ({{ site.default_rule_prefix }}1553)
-* Do not use optional parameters in interface methods or their concrete implementations ({{ site.default_rule_prefix }}1554)
-* Avoid using named arguments ({{ site.default_rule_prefix }}1555)
-* Don't declare signatures with more than 3 parameters ({{ site.default_rule_prefix }}1561)
+* Use concise conditional expressions instead of `if`-`else` blocks ({{ site.default_rule_prefix }}1545)
+* Prefer interpolated strings over concatenation or `string.Format` ({{ site.default_rule_prefix }}1546)
 * Don't use `ref` or `out` parameters ({{ site.default_rule_prefix }}1562)
-* Avoid signatures that take a `bool` flag ({{ site.default_rule_prefix }}1564)
-* Prefer `is` patterns over `as` operations ({{ site.default_rule_prefix }}1570)
-* Don't comment out code ({{ site.default_rule_prefix }}1575)
-* Write code that is easy to debug ({{ site.default_rule_prefix }}1580)
+* Avoid signatures that take a `bool` parameter ({{ site.default_rule_prefix }}1564)
+* Align projects and folders with deployment units, not architectural layers ({{ site.default_rule_prefix }}1578)
+* Make properties required when they must be set during initialization ({{ site.default_rule_prefix }}1585)
 
 <br/>
-**Framework Guidelines**
+**Performance**
 
-* Use C# type aliases instead of the types from the `System` namespace ({{ site.default_rule_prefix }}2201)
-* Prefer language syntax over explicit calls to underlying implementations ({{ site.default_rule_prefix }}2202)
-* Build with the highest warning level ({{ site.default_rule_prefix }}2210)
-* Use lambda expressions instead of anonymous methods ({{ site.default_rule_prefix }}2221)
-* Only use the `dynamic` keyword when talking to a dynamic object ({{ site.default_rule_prefix }}2230)
-* Favor `async`/`await` over `Task` continuations ({{ site.default_rule_prefix }}2235)
+* Consider using `Any()` to determine whether an `IEnumerable<T>` is empty ({{ site.default_rule_prefix }}1800)
+* Only use `async`/`await` for I/O-bound or long-running activities ({{ site.default_rule_prefix }}1820)
+* Prefer `Task.Run` for CPU-intensive activities ({{ site.default_rule_prefix }}1825)
+* Beware of `async`/`await` deadlocks in UI frameworks ({{ site.default_rule_prefix }}1835)
 </td>
-<tr>
+</tr>
+</table>
 
 <table width="100%" class="footer">
 <tr>
@@ -117,20 +110,20 @@ NOTE: Requires Markdown Extra. See http://michelf.ca/projects/php-markdown/extra
 </td>
 <td style="text-align:right">
   [www.csharpcodingguidelines.com](http://www.csharpcodingguidelines.com)
-  [www.continuousimprover.com](www.continuousimprover.com)
+  [www.dennisdoomen.com](https://www.dennisdoomen.com)
   [www.avivasolutions.nl](http://www.avivasolutions.nl)
 </td>
 </tr>
 </table>
 
 <table width="100%" style="page-break-before: always;">
- <tr>
-  <td class="title" width="70%">Coding Guidelines for C# v10 Cheat Sheet</td>
-  <td markdown="1" rowspan="2" style="text-align:right">![logo](assets/images/logo.svg)</td>
- </tr>
- <tr>
- <td><div class="subTitle">Naming & Layout</div> (level 1 and 2 only)</td>
- </tr>
+<tr>
+<td class="title" width="70%">Coding Guidelines for C# v14 Cheat Sheet</td>
+<td markdown="1" rowspan="2" style="text-align:right">![logo](assets/images/logo.svg)</td>
+</tr>
+<tr>
+<td><div class="subTitle">Testability, Naming & Style</div></td>
+</tr>
 </table>
 
 <table width="100%">
@@ -161,54 +154,61 @@ NOTE: Requires Markdown Extra. See http://michelf.ca/projects/php-markdown/extra
 </div>
 
 <br/>
+**Testability**
+
+* Use short concise functional test names ({{ site.default_rule_prefix }}1600)
+* Test observable behavior, not private implementation details ({{ site.default_rule_prefix }}1605)
+* Show what's important in a test, hide what's not ({{ site.default_rule_prefix }}1608)
+* Use Test Data Builders or Object Mothers to construct test objects ({{ site.default_rule_prefix }}1610)
+* Don't use production code in test assertions ({{ site.default_rule_prefix }}1618)
+* Test reusable components separately from their consumers ({{ site.default_rule_prefix }}1620)
+* Test concrete implementations as part of a larger integration scope ({{ site.default_rule_prefix }}1622)
+</td>
+<td class="column">
 **Naming**
 
 * Use US English ({{ site.default_rule_prefix }}1701)
+* Use proper casing for language elements ({{ site.default_rule_prefix }}1702)
 * Don't prefix fields ({{ site.default_rule_prefix }}1705)
 * Don't use abbreviations ({{ site.default_rule_prefix }}1706)
 * Name members, parameters and variables according to their meaning and not their type ({{ site.default_rule_prefix }}1707)
-* Name types using nouns, noun phrases or adjective phrases ({{ site.default_rule_prefix }}1708)
 * Name generic type parameters with descriptive names ({{ site.default_rule_prefix }}1709)
-* Don't repeat the name of a class or enumeration in its members ({{ site.default_rule_prefix }}1710)
-* Avoid short names or names that can be mistaken for other names ({{ site.default_rule_prefix }}1712)
 * Properly name properties ({{ site.default_rule_prefix }}1715)
 * Name methods and local functions using verbs or verb-object pairs ({{ site.default_rule_prefix }}1720)
 * Use a verb or verb phrase to name an event ({{ site.default_rule_prefix }}1735)
-* Postfix asynchronous methods with `Async` or `TaskAsync` ({{ site.default_rule_prefix }}1755)
-</td>
-<td class="column">
+* Use an underscore for irrelevant lambda parameters ({{ site.default_rule_prefix }}1739)
+* Only suffix methods with `Async` or `TaskAsync` when both synchronous and asynchronous variants exist ({{ site.default_rule_prefix }}1755)
 
-* Use an underscore for irrelevant parameters ({{ site.default_rule_prefix }}1739)
-
-
+<br/>
 **Documentation**
 
 * Write comments and documentation in US English ({{ site.default_rule_prefix }}2301)
 * Document all `public`, `protected` and `internal` types and members ({{ site.default_rule_prefix }}2305)
 * Write XML documentation with other developers in mind ({{ site.default_rule_prefix }}2306)
+* Document the purpose of a member, instead of describing its implementation ({{ site.default_rule_prefix }}2308)
 * Avoid inline comments ({{ site.default_rule_prefix }}2310)
 * Only write comments to explain complex algorithms or decisions ({{ site.default_rule_prefix }}2316)
-<br/>
-
-**Layout**
-
-* Maximum line length is 130 characters
-* Indent 4 spaces, don't use tabs
-* Keep one space between keywords like `if` and the expression, but don't add spaces after `(` and before `)`
-* Add a space around operators, like `+`, `-`, `==`, etc.
-* Always add curly braces after the keywords `if`, `else`, `do`, `while`, `for`, `foreach` and `case` ({{ site.default_rule_prefix }}1535)
-* Always put opening and closing curly braces on a new line
-* Don't indent object/collection initializers and initialize each property on a new line
-* Don't indent lambda statement blocks
-* Keep expression-bodied-members on one line; break long lines after the arrow sign
-* Put the entire LINQ statement on one line, or start each keyword at the same indentation
-* Remove redundant parentheses in expressions if they do not clarify precedence; add parentheses in expressions to avoid non-obvious precedence
-<br/>
-
-* Do not use `#region` ({{ site.default_rule_prefix }}2407)
-* Use expression-bodied members appropriately ({{ site.default_rule_prefix }}2410)
 </td>
 <td class="column">
+**Framework**
+
+* Prefer idiomatic C# over .NET Framework APIs ({{ site.default_rule_prefix }}2202)
+* Build with the highest warning level ({{ site.default_rule_prefix }}2210)
+* Avoid LINQ query syntax for simple expressions ({{ site.default_rule_prefix }}2220)
+* Use deconstruction to simplify variable assignments ({{ site.default_rule_prefix }}2225)
+* Only use the `dynamic` keyword when talking to a dynamic object ({{ site.default_rule_prefix }}2230)
+
+<br/>
+**Layout**
+
+* Use a common layout ({{ site.default_rule_prefix }}2400)
+* Order and group namespaces according to the company ({{ site.default_rule_prefix }}2402)
+* Place members in a well-defined order ({{ site.default_rule_prefix }}2406)
+* Do not use `#region` ({{ site.default_rule_prefix }}2407)
+* Use expression-bodied members appropriately ({{ site.default_rule_prefix }}2410)
+* Indent 4 spaces, don't use tabs
+* Add spaces around operators and after keywords such as `if`
+* Keep expression-bodied members on one line when they remain readable
 
 <div markdown="1" class="sidebar">
 **Empty lines**
@@ -232,9 +232,9 @@ NOTE: Requires Markdown Extra. See http://michelf.ca/projects/php-markdown/extra
 7. Public properties
 8. Other methods and private properties in calling order
 </div>
-
-<td/>
-<tr>
+</td>
+</tr>
+</table>
 
 <table width="100%" class="footer">
 <tr>
@@ -244,7 +244,7 @@ NOTE: Requires Markdown Extra. See http://michelf.ca/projects/php-markdown/extra
  </td>
  <td style="text-align:right">
   [www.csharpcodingguidelines.com](http://www.csharpcodingguidelines.com)
-  [www.continuousimprover.com](www.continuousimprover.com)
+  [www.dennisdoomen.com](https://www.dennisdoomen.com)
   [www.avivasolutions.nl](http://www.avivasolutions.nl)
   </td>
 </tr>

--- a/assets/css/CheatSheet.css
+++ b/assets/css/CheatSheet.css
@@ -42,7 +42,7 @@ p, blockquote, ul, ol, dl, pre {
 h1, h2, h3, h4, h5, h6 {
   font-family: Variable Bold, Calibri, Helvetica, arial, freesans, clean, sans-serif;
   margin: 20px 0 10px;
-  color: rgb(167, 21, 0);
+  color: #1672f3;
   padding: 0;
   font-weight: bold;
   -webkit-font-smoothing: antialiased;
@@ -295,7 +295,7 @@ img {
     font-family: Variable Bold, Calibri;
 	font-size: 19pt;
   	line-height: 1;
-  	color: rgb(167, 21, 0);
+  	color: #1672f3;
     text-align: left;
     font-weight: bold;
     display: inline;
@@ -310,7 +310,7 @@ img {
 
 .sidebar
 {
-	background-color: rgb(167, 21, 0);
+	background-color: #1672f3;
   color: white;
   line-height: 1;
   padding-left: 8px;
@@ -321,13 +321,13 @@ img {
 }
   .sidebar strong
   {
-    background-color: rgb(167, 21, 0);
+    background-color: #1672f3;
     color: white;
   }
 
   .sidebar code
   {
-    background-color: rgb(167, 21, 0);
+    background-color: #1672f3;
     border: 0;
     color: white;
   }
@@ -340,13 +340,13 @@ img {
 
 .footer
 {
-  color: rgb(167, 21, 0);
+  color: #1672f3;
   line-height: 1;
 }
 
   .footer a
   {
-    color: rgb(167, 21, 0);
+    color: #1672f3;
   }
 
 img[src*="logo.svg"]
@@ -356,7 +356,7 @@ img[src*="logo.svg"]
 
 td strong
 {
-  color: rgb(167, 21, 0);
+  color: #1672f3;
   display: inline-block;
 }
 

--- a/assets/css/Guidelines.css
+++ b/assets/css/Guidelines.css
@@ -46,7 +46,7 @@ p, blockquote, ul, ol, dl, table, pre {
 h1, h2, h3, h4, h5, h6 {
   font-family: Variable Bold, Calibri, Arial;
   margin: 20px 0 10px;
-  color: rgb(167, 21, 0);
+  color: #1672f3;
   padding: 0;
   font-weight: bold;
   -webkit-font-smoothing: antialiased;
@@ -304,7 +304,7 @@ img {
     font-family: Variable Bold, Arial;
 	font-size: 29pt;
 	line-height: 1;
-	color: rgb(167, 21, 0);
+	color: #1672f3;
     text-align: center;
     font-weight: bold;
 }


### PR DESCRIPTION
## Summary
- refresh the cheatsheet so it reflects the current guideline set, covers all sections, and removes severity-based wording
- fix `Build.bat` for worktree checkouts and stop emitting missing severity image references
- update the document branding by switching the accent color to `#1672f3`, changing the cheatsheet to C# v14, and replacing the footer link with `https://www.dennisdoomen.com`

## Testing
- run `Build.bat`