### PR TITLE
Fix rule_id displaying as wrong number on GitHub for rules 0100–0135

### DIFF
--- a/_rules/0100.md
+++ b/_rules/0100.md
@@ -1,5 +1,5 @@
 ---
-rule_id: 0100
+rule_id: "0100"
 rule_category: general
 title: Understand the boundaries of your codebase
 ---

--- a/_rules/0105.md
+++ b/_rules/0105.md
@@ -1,5 +1,5 @@
 ---
-rule_id: 0105
+rule_id: "0105"
 rule_category: general
 title: Use design patterns to communicate intent
 ---

--- a/_rules/0110.md
+++ b/_rules/0110.md
@@ -1,5 +1,5 @@
 ---
-rule_id: 0110
+rule_id: "0110"
 rule_category: general
 title: Prefer composition over inheritance
 ---

--- a/_rules/0112.md
+++ b/_rules/0112.md
@@ -1,5 +1,5 @@
 ---
-rule_id: 0112
+rule_id: "0112"
 rule_category: general
 title: Apply the Principle of Least Surprise
 ---

--- a/_rules/0115.md
+++ b/_rules/0115.md
@@ -1,5 +1,5 @@
 ---
-rule_id: 0115
+rule_id: "0115"
 rule_category: general
 title: Keep It Simple Stupid (KISS)
 ---

--- a/_rules/0120.md
+++ b/_rules/0120.md
@@ -1,5 +1,5 @@
 ---
-rule_id: 0120
+rule_id: "0120"
 rule_category: general
 title: You Ain't Gonna Need It (YAGNI)
 ---

--- a/_rules/0125.md
+++ b/_rules/0125.md
@@ -1,5 +1,5 @@
 ---
-rule_id: 0125
+rule_id: "0125"
 rule_category: general
 title: Don't Repeat Yourself (DRY), but only within boundaries
 ---

--- a/_rules/0130.md
+++ b/_rules/0130.md
@@ -1,5 +1,5 @@
 ---
-rule_id: 0130
+rule_id: "0130"
 rule_category: general
 title: Apply the four pillars of object-oriented programming
 ---

--- a/_rules/0135.md
+++ b/_rules/0135.md
@@ -1,5 +1,5 @@
 ---
-rule_id: 0135
+rule_id: "0135"
 rule_category: general
 title: Treat AI-generated code as your own
 ---


### PR DESCRIPTION
## Problem

Rules with IDs between 0100 and 0135 display the wrong `rule_id` value when viewed on GitHub. For example, `0100.md` shows `rule_id: 64` instead of `0100`.

This happens because YAML 1.1 (used by Jekyll) interprets unquoted numbers with a leading zero as octal. So `0100` (octal) = `64` (decimal).

## Fix

Quote the `rule_id` values in the 9 affected files so YAML treats them as strings:

| File | Displayed as (before) | Displays as (after) |
|------|----------------------|---------------------|
| 0100.md | 64 | 0100 |
| 0105.md | 69 | 0105 |
| 0110.md | 72 | 0110 |
| 0112.md | 74 | 0112 |
| 0115.md | 77 | 0115 |
| 0120.md | 80 | 0120 |
| 0125.md | 85 | 0125 |
| 0130.md | 88 | 0130 |
| 0135.md | 93 | 0135 |